### PR TITLE
require explicit staging in recommended check-skipping function

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ gitforce() {
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
         git config --local hooks.gitleaks false
-        git commit -am "$@" 
+        git commit -m "$@" 
         git config --local hooks.gitleaks true
     fi
 }


### PR DESCRIPTION
# Changes proposed in this PR
I think this bash function would be better if it required explicit staging of files before force-committing, so users don't accidentally skip checks on more files than necessary

# Security considerations
I think if users follow this recommendation, the proposed version is less likely to result in accidentally-committed secrets