### PR TITLE
`audit` should include user and timestamp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ ME=$(shell whoami)
 
 INSTALL_TARGETS= hook global_hooks patterns
 
-.PHONY: $(INSTALL_TARGETS) clean install audit
+.PHONY: $(INSTALL_TARGETS) clean install audit config
 
 install: /usr/local/bin/gitleaks $(INSTALL_TARGETS)
 
@@ -30,7 +30,7 @@ global_hooks:
 	git config --global hooks.gitleaks true
 	git config --global core.hooksPath ${GIT_SUPPORT_PATH}/hooks
 
-patterns: ${GIT_SUPPORT_PATH}/gitleaks.toml
+config patterns: ${GIT_SUPPORT_PATH}/gitleaks.toml
 
 ${GIT_SUPPORT_PATH}/gitleaks.toml: leaky-repo.toml local.toml
 	cat $^ > $@
@@ -41,7 +41,6 @@ leaky-repo.toml: FORCE
 ${GIT_SUPPORT_PATH}/hooks/pre-commit: pre-commit.sh
 	mkdir -p ${GIT_SUPPORT_PATH}/hooks
 	install -m 0755 -cv $< $@
-	cp $< $@
 
 /usr/local/bin/bats:
 	brew install bats-core

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 GIT_SUPPORT_PATH=  ${HOME}/.git-support
 RAW_GITLEAKS= https://raw.githubusercontent.com/zricethezav/gitleaks
 GITLEAKS_VERSION=v4.1.0
+NOW=$(shell date)
+ME=$(shell whoami)
 
 INSTALL_TARGETS= hook global_hooks patterns
 
@@ -19,6 +21,7 @@ clean_seekrets:
 	-git config --global --unset gitseekret.version
 
 audit: /usr/local/bin/bats /usr/local/bin/pcregrep 
+	@echo "${ME} / ${NOW}"
 	bats -t caulked.bats
 
 hook: ${GIT_SUPPORT_PATH}/hooks/pre-commit

--- a/check_repos.sh
+++ b/check_repos.sh
@@ -40,7 +40,7 @@ check_hooks_gitleaks() {
 check_precommit_hook() {
     set -xv
     if [ -f $gitrepo/hooks/pre-commit ]; then
-      pcregrep -q '^((?!#).)*gitleaks.*$' $gitrepo/hooks/pre-commit
+      pcregrep -q '^((?!#).)*gitleaks\s.*$' $gitrepo/hooks/pre-commit
       return $?
     fi
     return 0


### PR DESCRIPTION
## Changes proposed in this pull request:

-  `check-repos.sh` has a better (but still naive check) for `gitleaks` as an executable being in a hook script
-  `make audit` should include user and timestamp
- some Makefile cleanup

## security considerations

None: largely cosmetic