### PR TITLE
Combine rules files and adjust email filters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 GIT_SUPPORT_PATH=  ${HOME}/.git-support
-RAW_GITLEAKS= https://raw.githubusercontent.com/zricethezav/gitleaks
-GITLEAKS_VERSION=v4.1.0
 NOW=$(shell date)
 ME=$(shell whoami)
 
@@ -10,7 +8,7 @@ INSTALL_TARGETS= hook global_hooks patterns
 
 install: /usr/local/bin/gitleaks $(INSTALL_TARGETS)
 
-clean: 
+clean:
 	/bin/rm -f ${GIT_SUPPORT_PATH}/hooks/pre-commit
 
 clean_seekrets:
@@ -20,23 +18,20 @@ clean_seekrets:
 	-git config --global --unset gitseekret.exceptionsfile
 	-git config --global --unset gitseekret.version
 
-audit: /usr/local/bin/bats /usr/local/bin/pcregrep 
+audit: /usr/local/bin/bats /usr/local/bin/pcregrep
 	@echo "${ME} / ${NOW}"
 	bats -t caulked.bats
 
 hook: ${GIT_SUPPORT_PATH}/hooks/pre-commit
 
-global_hooks: 
+global_hooks:
 	git config --global hooks.gitleaks true
 	git config --global core.hooksPath ${GIT_SUPPORT_PATH}/hooks
 
 config patterns: ${GIT_SUPPORT_PATH}/gitleaks.toml
 
-${GIT_SUPPORT_PATH}/gitleaks.toml: leaky-repo.toml local.toml
+${GIT_SUPPORT_PATH}/gitleaks.toml: local.toml
 	cat $^ > $@
-
-leaky-repo.toml: FORCE
-	curl --silent ${RAW_GITLEAKS}/${GITLEAKS_VERSION}/examples/$@ -o $@
 
 ${GIT_SUPPORT_PATH}/hooks/pre-commit: pre-commit.sh
 	mkdir -p ${GIT_SUPPORT_PATH}/hooks

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Caulking stops leaks
 
-![caulking gun with grey caulk oozing out](https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Caulking.jpg/757px-Caulking.jpg)
+![caulking gun with grey caulk oozing out](https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Caulking.jpg/757px-Caulking.jpg =364x288)
 
 Goals:
 
@@ -24,23 +24,21 @@ To get rid of `git-seekrets` configuration, run `make clean_seekrets`
 
 If you get the error `reference not found` on a new repository it's due to this issue: [Gitleaks --uncommitted fails on first commit](https://github.com/zricethezav/gitleaks/issues/352). To fix you'll need to temporarily disable the pre-commit hook.
 
-## Auditing notes
+## Auditing notes - how to test if this is working
 
-The `make audit` target installs prerequisites then runs the test harness `bats caulked.bats`. 
+The `make audit` target installs prerequisites then runs the test harness `bats caulked.bats` and outputs whether the tests pass or fail. All tests must pass to be considered a successful install/audit.
 
-The tests check for a working gitleaks setup, and that you haven't inadvertently disabled gitleaks in your repositories. It checks:
+The tests check for a working `gitleaks` setup, and that you haven't inadvertently disabled `gitleaks` in your repositories. It checks:
 
 * that common patterns of secrets cause a commit to fail
 * that `hooks.gitleaks` is set to true underneath $HOME to $MAXDEPTH setting
 * that any custom `/.git/hooks/pre-commit` scripts also still call `gitleaks`
 
-These assume a compliant engineer who wants to abide by use of `gitleaks`, and 
-doesn't deliberately subvert that intent.
+These assume a compliant engineer who wants to abide by use of `gitleaks`,and  doesn't deliberately subvert that intent.
 
 ## What now?
 
-You have installed gitleaks and our patterns, and you've verified that all of your
-repositories are not inadvertently sidestepping the caulking. Continue on with your day. We may periodically ask you to run `make patterns` and `make audit` to update your rules and test that you are still protected from committing known secret patterns.
+You have installed gitleaks and our patterns, and you've verified that all of your repositories are not inadvertently sidestepping the caulking. Continue on with your day. We may periodically ask you to run `make patterns` and `make audit` to update your rules and test that you are still protected from committing known secret patterns.
 
 If you get a `git commit` error message like this:
 
@@ -73,7 +71,7 @@ You have a couple of choices:
         git commit -m "message" 
         git config --local hooks.gitleaks true
 
-You may want to have `.bashrc` function like:
+You may want to add function to your `.bashrc` profile like:
 
 ```
 gitforce() {
@@ -93,7 +91,7 @@ gitforce() {
 Here are some shortcuts:
 
 - `make hook`: update `~/.git-support/hooks/pre-commit` from local `pre-commit.sh`
-- `make patterns`: update the `gitleaks` configuration in `~/.git-support/gitleaks.toml` from local `local.toml` plus upstream rules from the GitLeaks project
+- `make patterns`: update the `gitleaks` configuration in `~/.git-support/gitleaks.toml` from local `local.toml` plus upstream rules from the [GitLeaks](https://github.com/zricethezav/gitleaks) project
 
 # Public domain
 

--- a/caulked.bats
+++ b/caulked.bats
@@ -8,7 +8,7 @@
 #              make clean_gitleaks install`
 # Running Tests:
 #   make audit
-#      
+#
 
 load test_helper
 
@@ -34,6 +34,21 @@ load test_helper
     [ ${status} -eq 1 ]
 }
 
+@test "leak prevention allows support and inquiries emails" {
+    run addFileWithCGEmails
+    [ ${status} -eq 1 ]
+}
+
+@test "leak prevention allows github emails" {
+    run addFileWithGithubEmails
+    [ ${status} -eq 1 ]
+}
+
+@test "leak prevention catches normal email addresses in test repo" {
+    run addFileWithSecretEmail
+    [ ${status} -eq 1 ]
+}
+
 @test "leak prevention catches Slack api token in test repo" {
     run addFileWithSlackAPIToken
     [ ${status} -eq 1 ]
@@ -48,7 +63,7 @@ load test_helper
     ./check_repos.sh $HOME check_hooks_gitleaks >&3
 }
 
-@test "repos are using precommit hooks with gitleaks" { 
+@test "repos are using precommit hooks with gitleaks" {
     ./check_repos.sh $HOME check_precommit_hook >&3
 }
 

--- a/local.toml
+++ b/local.toml
@@ -1,4 +1,6 @@
-# rules borrowed from GSA 
+title = "gitleaks config"
+
+# Rules borrowed from GSA
 # https://github.com/GSA/odp-code-repository-commit-rules/blob/master/gitleaks/rules.toml
 
 # If IPv4 is overbroad, cloud.gov external IPs may all be nonsensitive
@@ -8,7 +10,6 @@
 	regex = '''[\W\D]?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}[\W\D]?'''
 	tags = ["IPv4", "IP", "addresses"]
 
-# Commented out in upstream `leaky-repo.tom`, using here:
 [[rules]]
 	description = "s3config"
   	regex = '''(?i)(dbpasswd|dbuser|dbname|dbhost|api_key|apikey|key|api|password|user|guid|hostname|pw|auth)(.{0,3})?([0-9a-zA-Z-_\/+!{}=]{4,120})'''
@@ -19,3 +20,206 @@
 	regex = '''(?i)(password|enc.key|auth.pass): '''
   	fileNameRegex = '''(?i)(\.yml|\.yaml)'''
 	tags = ["yaml"]
+
+[[rules]]
+	description = "Email"
+	regex = '''[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}'''
+	tags = ["email"]
+	[[rules.whitelist]]
+		file = '''(?i)bashrc'''
+		description = "ignore bashrc emails"
+	[[rules.whitelist]]
+		file = '''(?i)support@cloud.gov'''
+		description = "ignore support@cloud.gov"
+	[[rules.whitelist]]
+		file = '''(?i)inquiries@cloud.gov'''
+		description = "ignore inquiries@cloud.gov"
+	[[rules.whitelist]]
+		file = '''(?i)[a-zA-Z0-9._%+-]+@github.com'''
+		description = "ignore github emails"
+
+# Rules from original `leaky-repo.toml` v4.1.0
+# https://raw.githubusercontent.com/zricethezav/gitleaks
+
+[[rules]]
+	description = "AWS Manager ID"
+	regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+	tags = ["key", "AWS"]
+
+[[rules]]
+	description = "AWS cred file info"
+	regex = '''(?i)(aws_access_key_id|aws_secret_access_key)(.{0,20})?=.[0-9a-zA-Z\/+]{20,40}'''
+	tags = ["AWS"]
+
+[[rules]]
+	description = "AWS Secret Key"
+	regex = '''(?i)aws(.{0,20})?(?-i)['\"][0-9a-zA-Z\/+]{40}['\"]'''
+	tags = ["key", "AWS"]
+
+[[rules]]
+	description = "AWS MWS key"
+	regex = '''amzn\.mws\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}'''
+	tags = ["key", "AWS", "MWS"]
+
+[[rules]]
+	description = "Facebook Secret Key"
+	regex = '''(?i)(facebook|fb)(.{0,20})?(?-i)['\"][0-9a-f]{32}['\"]'''
+	tags = ["key", "Facebook"]
+
+[[rules]]
+	description = "Facebook Client ID"
+	regex = '''(?i)(facebook|fb)(.{0,20})?['\"][0-9]{13,17}['\"]'''
+	tags = ["key", "Facebook"]
+
+[[rules]]
+	description = "Twitter Secret Key"
+	regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{35,44}['\"]'''
+	tags = ["key", "Twitter"]
+
+[[rules]]
+	description = "Twitter Client ID"
+	regex = '''(?i)twitter(.{0,20})?['\"][0-9a-z]{18,25}['\"]'''
+	tags = ["client", "Twitter"]
+
+[[rules]]
+	description = "Github"
+	regex = '''(?i)github(.{0,20})?(?-i)['\"][0-9a-zA-Z]{35,40}['\"]'''
+	tags = ["key", "Github"]
+
+[[rules]]
+	description = "LinkedIn Client ID"
+	regex = '''(?i)linkedin(.{0,20})?(?-i)['\"][0-9a-z]{12}['\"]'''
+	tags = ["client", "LinkedIn"]
+
+[[rules]]
+	description = "LinkedIn Secret Key"
+	regex = '''(?i)linkedin(.{0,20})?['\"][0-9a-z]{16}['\"]'''
+	tags = ["secret", "LinkedIn"]
+
+[[rules]]
+	description = "Slack"
+	regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})?'''
+	tags = ["key", "Slack"]
+
+[[rules]]
+	description = "EC"
+	regex = '''-----BEGIN EC PRIVATE KEY-----'''
+	tags = ["key", "EC"]
+
+[[rules]]
+	description = "Google API key"
+	regex = '''AIza[0-9A-Za-z\\-_]{35}'''
+	tags = ["key", "Google"]
+
+
+[[rules]]
+	description = "Heroku API key"
+	regex = '''(?i)heroku(.{0,20})?['"][0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}['"]'''
+	tags = ["key", "Heroku"]
+
+[[rules]]
+	description = "MailChimp API key"
+	regex = '''(?i)(mailchimp|mc)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]'''
+	tags = ["key", "Mailchimp"]
+
+[[rules]]
+	description = "Mailgun API key"
+	regex = '''(?i)(mailgun|mg)(.{0,20})?['"][0-9a-z]{32}['"]'''
+	tags = ["key", "Mailgun"]
+
+[[rules]]
+	description = "PayPal Braintree access token"
+	regex = '''access_token\$production\$[0-9a-z]{16}\$[0-9a-f]{32}'''
+	tags = ["key", "Paypal"]
+
+[[rules]]
+	description = "Picatic API key"
+	regex = '''sk_live_[0-9a-z]{32}'''
+	tags = ["key", "Picatic"]
+
+[[rules]]
+	description = "Slack Webhook"
+	regex = '''https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}'''
+	tags = ["key", "slack"]
+
+[[rules]]
+	description = "Stripe API key"
+	regex = '''(?i)stripe(.{0,20})?['\"][sk|rk]_live_[0-9a-zA-Z]{24}'''
+	tags = ["key", "Stripe"]
+
+[[rules]]
+	description = "Square access token"
+	regex = '''sq0atp-[0-9A-Za-z\-_]{22}'''
+	tags = ["key", "square"]
+
+[[rules]]
+	description = "Square OAuth secret"
+	regex = '''sq0csp-[0-9A-Za-z\\-_]{43}'''
+	tags = ["key", "square"]
+
+[[rules]]
+	description = "Twilio API key"
+	regex = '''(?i)twilio(.{0,20})?['\"][0-9a-f]{32}['\"]'''
+	tags = ["key", "twilio"]
+
+[[rules]]
+	description = "Env Var"
+	regex = '''(?i)(apikey|secret|key|api|password|pass|pw|host)=[0-9a-zA-Z-_.{}]{4,120}'''
+
+[[rules]]
+	description = "Port"
+	regex = '''(?i)port(.{0,4})?[0-9]{1,10}'''
+	[[rules.whitelist]]
+		regex = '''(?i)port '''
+		description = "ignore export "
+
+[[rules]]
+	description = "Generic Credential"
+	regex = '''(?i)(dbpasswd|dbuser|dbname|dbhost|api_key|apikey|secret|key|api|password|user|guid|hostname|pw|auth)(.{0,20})?['|"]([0-9a-zA-Z-_\/+!{}/=]{4,120})['|"]'''
+	tags = ["key", "API", "generic"]
+	# ignore leaks with specific identifiers like slack and aws
+	[[rules.whitelist]]
+		regex = '''xox[baprs]-([0-9a-zA-Z]{10,48})'''
+		description = "ignore slack"
+	[[rules.whitelist]]
+		description = "MailChimp API key"
+		regex = '''(?i)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]'''
+	[[rules.whitelist]]
+		description = "AWS Manager ID"
+		regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+
+[[rules]]
+	description = "High Entropy"
+	regex = '''[0-9a-zA-Z-_!{}/=]{4,120}'''
+  	fileNameRegex = '''(?i)(dump.sql|high-entropy-misc.txt)$'''
+	tags = ["entropy"]
+        [[rules.Entropies]]
+            Min = "4.3"
+            Max = "7.0"
+        [[rules.whitelist]]
+            description = "ignore ssh key and pems"
+            file = '''(pem|ppk|env)$'''
+            path = '''(.*)?ssh'''
+
+[[rules]]
+	description = "Potential bash var"
+	regex='''(?i)(=)([0-9a-zA-Z-_!{}=]{4,120})'''
+	tags = ["key", "bash", "API", "generic"]
+        [[rules.Entropies]]
+            Min = "3.5"
+            Max = "4.5"
+            Group = "1"
+
+[[rules]]
+	description = "WP-Config"
+	regex='''define(.{0,20})?(DB_CHARSET|NONCE_SALT|LOGGED_IN_SALT|AUTH_SALT|NONCE_KEY|DB_HOST|DB_PASSWORD|AUTH_KEY|SECURE_AUTH_KEY|LOGGED_IN_KEY|DB_NAME|DB_USER)(.{0,20})?['|"].{10,120}['|"]'''
+	tags = ["key", "API", "generic"]
+
+[[rules]]
+	description = "Files with keys and credentials"
+    fileNameRegex = '''(?i)(id_rsa|passwd|id_rsa.pub|pgpass|pem|key|shadow)'''
+
+[whitelist]
+	description = "image whitelists"
+	file = '''(.*?)(jpg|gif|doc|pdf|bin)$'''
+

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -48,7 +48,34 @@ addFileWithAwsAccessKey() {
     local secrets_file="${REPO_PATH}/accessfile.md"
     cat >${secrets_file} <<END
 SHHHH... Secrets in this file
-AWS_ACCESS_KEY_ID: AKIAJLLCKKYFEWP5MWXA 
+AWS_ACCESS_KEY_ID: AKIAJLLCKKYFEWP5MWXA
+END
+    testCommit $secrets_file
+}
+
+addFileWithCGEmails() {
+    local secrets_file="${REPO_PATH}/cgemailfile.md"
+    cat >${secrets_file} <<END
+No secrets in this file
+Email addresses like support@cloud.gov and inquiries@cloud.gov
+END
+    testCommit $secrets_file
+}
+
+addFileWithGithubEmails() {
+    local secrets_file="${REPO_PATH}/ghemailfile.md"
+    cat >${secrets_file} <<END
+No secrets in this file
+Email address like noreply@github.com or support@github.com
+END
+    testCommit $secrets_file
+}
+
+addFileWithSecretEmail() {
+    local secrets_file="${REPO_PATH}/emailfile.md"
+    cat >${secrets_file} <<END
+SHHHH... Secrets in this file
+Email address like test@example.com
 END
     testCommit $secrets_file
 }


### PR DESCRIPTION
## Changes proposed in this pull request:
- Edits the Makefile to change how the rules file gets created
- Adds rule whitelisting for github and the cloud.gov support/inquiries emails
- Adds tests for email rules
- Removes some trailing whitespace
- Updates Readme

This PR is in response to issue #8 - relax email matching and partially addresses it.

## Update note

Please note: you will need to rerun `make install` to load the new rules. You can delete your local copy of `leaky-repo.toml` which is subject to the `.gitignore` file.

## How to test

1. Rerun `make install` to reload the rules.
2. Then, run `make audit` and verify that all the tests pass.

## Security considerations
No security considerations as they are the same rules just pre-concatenated into one file
