### PR TITLE
Fixed whitelist for email and dev process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Caulking stops leaks
 
-![caulking gun with grey caulk oozing out](https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Caulking.jpg/757px-Caulking.jpg=364x288)
+![caulking gun with grey caulk oozing out](https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Caulking.jpg/757px-Caulking.jpg)
 
 Goals:
 

--- a/README.md
+++ b/README.md
@@ -88,10 +88,13 @@ gitforce() {
 
 # Development tips
 
-Here are some shortcuts:
+To work on patterns, add test cases to `development.bats`, update patterns in `local.toml` then
+run `bats development.bats`.  Here are some shortcuts
 
 - `make hook`: update `~/.git-support/hooks/pre-commit` from local `pre-commit.sh`
-- `make patterns`: update the `gitleaks` configuration in `~/.git-support/gitleaks.toml` from local `local.toml` plus upstream rules from the [GitLeaks](https://github.com/zricethezav/gitleaks) project
+- `make patterns`: update the `gitleaks` configuration in `~/.git-support/gitleaks.toml` from local `local.toml` 
+- `make audit`: see that everything work togethe.
+
 
 ## Rule sets
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Caulking stops leaks
 
-![caulking gun with grey caulk oozing out](https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Caulking.jpg/757px-Caulking.jpg =364x288)
+![caulking gun with grey caulk oozing out](https://upload.wikimedia.org/wikipedia/commons/thumb/3/37/Caulking.jpg/757px-Caulking.jpg=364x288)
 
 Goals:
 

--- a/caulked.bats
+++ b/caulked.bats
@@ -11,11 +11,15 @@
 #              make clean_gitleaks install`
 # Running Tests:
 #   make audit
-#
+# 
+# Development note: These tests all assume that your root
+# ~/.git-support/gitleaks.toml are up to date. If you're testing
+# `local.toml` then use `development.bats` (or use `make patterns` 
+# before `make audit`)
 
 load test_helper
 
-@test "leak prevention allows plain text" {
+@test "leak prevention allows plain text, check `git config --global -l` on failure" {
     run addFileWithNoSecrets
     [ ${status} -eq 0 ]
     echo ${lines[0]} | grep -q "No leaks detected in staged changes"
@@ -37,15 +41,6 @@ load test_helper
     [ ${status} -eq 1 ]
 }
 
-@test "leak prevention allows support and inquiries emails" {
-    run addFileWithCGEmails
-    [ ${status} -eq 1 ]
-}
-
-@test "leak prevention allows github emails" {
-    run addFileWithGithubEmails
-    [ ${status} -eq 1 ]
-}
 
 @test "leak prevention catches normal email addresses in test repo" {
     run addFileWithSecretEmail

--- a/caulked.bats
+++ b/caulked.bats
@@ -19,7 +19,7 @@
 
 load test_helper
 
-@test "leak prevention allows plain text, check `git config --global -l` on failure" {
+@test "leak prevention allows plain text, check 'git config --global -l' on failure" {
     run addFileWithNoSecrets
     [ ${status} -eq 0 ]
     echo ${lines[0]} | grep -q "No leaks detected in staged changes"

--- a/caulked.bats
+++ b/caulked.bats
@@ -84,3 +84,13 @@ load test_helper
     run yamlTest "development-auth-pass: woothothae5IezaiD8gu0eiweKui4sah"
     [ ${status} -eq 1 ]
 }
+
+# Note that we're not using a function in `test_helper.bash`, which 
+# may be easier to maintain and understand. PDB 2020-05-12
+@test "it catches base64 40char potential AWS secret key" {
+    cat > $REPO_PATH/random.txt <<END
+Login with this secret: +awsSecretAccessKeyisBase64=40characters
+END
+    run testCommit $REPO_PATH
+    [ ${status} -eq 1 ]
+}

--- a/development.bats
+++ b/development.bats
@@ -1,17 +1,20 @@
 #!/usr/bin/env bats
 #
-# bats test file for testing that caulking
-# prevents leaking secrets.
-#
-# Prerequisites:
-#     * gitleaks and rules are installed with `
-#              make clean_gitleaks install`
-#              brew install bats-core
+# To keep `make audit` runs short with `caulked.bats`, this file
+# includes the rules for `allow`.  Also includes tests
+# that only make sense during development on the 
+# developers system
+
 # Running Tests:
 #
-#              bats leakproof.bats
+#              bats development.bats
 
 load test_helper
+
+# override testCommit to use local.toml in development
+testCommit() {
+    gitleaks --config=./local.toml --repo-path=${REPO_PATH} --uncommitted
+}
 
 @test "turning off hooks.gitleaks on a repo" {
     run turnOffHooksGitleaks
@@ -33,5 +36,36 @@ load test_helper
 @test "creating precommit w OK gitleaks in a repo" {
     run createPrecommitOKGitleaks
     run ./check_repos.sh $REPO_PATH check_precommit_hook >&3
+    [ ${status} -eq 0 ]
+}
+
+@test "leak prevention allows support and inquiries emails" {
+    run addFileWithCGEmails
+    [ ${status} -eq 0 ]
+}
+
+@test "leak prevention allows github emails" {
+    run addFileWithGithubEmails
+    [ ${status} -eq 0 ]
+}
+
+@test "leak prevention allows yaml interpolated values in (()) or {{}}" {
+    run addFileWithInterpolatedYamlPassword
+    [ ${status} -eq 0 ]
+}
+
+@test "ingore ipv4-ish in svg" {
+    cat > $REPO_PATH/ok.svg <<END
+"\u003csvg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 233 47\" id=\"logo\"\u003e\u003ctitle\u003elogo\u003c/title\u003e\u003cg fill=\"none\" fill-rule=\"evenodd\"\u003e\u003cpath d=\"M57.547 18.534a3.71 3.71 0 0 2.403.268.729. 0-1.679-1.276 5.563 5.563 0 0 0-2.02...",
+END
+    run testCommit $REPO_PATH/ok.svg
+    [ ${status} -eq 0 ]
+}
+
+@test "ignore author copyright with email" {
+    cat > $REPO_PATH/email.md <<END
+Author: pburkholder@example.com
+END
+    run testCommit $REPO_PATH/email.md
     [ ${status} -eq 0 ]
 }

--- a/development.bats
+++ b/development.bats
@@ -56,9 +56,9 @@ testCommit() {
 
 @test "ingore ipv4-ish in svg" {
     cat > $REPO_PATH/ok.svg <<END
-"\u003csvg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 233 47\" id=\"logo\"\u003e\u003ctitle\u003elogo\u003c/title\u003e\u003cg fill=\"none\" fill-rule=\"evenodd\"\u003e\u003cpath d=\"M57.547 18.534a3.71 3.71 0 0 2.403.268.729. 0-1.679-1.276 5.563 5.563 0 0 0-2.02...",
+"\u003csvg xmlns=\"http://www.w3.org/2000/svg\" d=\"M57.547 18.534a3.71 3.71 0 0 10.20.30.40 0-1.679-1.276 5.563 5.563 0 0 0-2.02...",
 END
-    run testCommit $REPO_PATH/ok.svg
+    run testCommit $REPO_PATH
     [ ${status} -eq 0 ]
 }
 
@@ -66,6 +66,6 @@ END
     cat > $REPO_PATH/email.md <<END
 Author: pburkholder@example.com
 END
-    run testCommit $REPO_PATH/email.md
+    run testCommit $REPO_PATH
     [ ${status} -eq 0 ]
 }

--- a/development.bats
+++ b/development.bats
@@ -5,6 +5,8 @@
 # that only make sense during development on the 
 # developers system
 
+# Bug bounty folks: Any apparent keys or passwords are just test strings
+
 # Running Tests:
 #
 #              bats development.bats
@@ -65,6 +67,22 @@ END
 @test "ignore author copyright with email" {
     cat > $REPO_PATH/email.md <<END
 Author: pburkholder@example.com
+END
+    run testCommit $REPO_PATH
+    [ ${status} -eq 0 ]
+}
+
+@test "false negative OK on presumed AWS secret key" {
+    cat > $REPO_PATH/random.txt <<END
+foo=+awsSecretAccessKeyisBase64=40characters
+END
+    run testCommit $REPO_PATH
+    [ ${status} -eq 0 ]
+}
+
+@test "Pass on 41 character long base64 string" {
+    cat > $REPO_PATH/random.txt <<END
+Can't login with this secret: +1awsSecretAccessKeyisBase64=40characters
 END
     run testCommit $REPO_PATH
     [ ${status} -eq 0 ]

--- a/local.toml
+++ b/local.toml
@@ -42,6 +42,21 @@ title = "gitleaks config"
 		regex = '''(?i)(Author|Copyright|Contact)'''
 		description = "ignore explict author or copyright email"
 
+# The proper Perl regex for AWS secret keys is
+# (?<![A-Za-z0-9\\+])[A-Za-z0-9\\+=]{40}(?![A-Za-z0-9\\+=])
+# but the Go library doesn't do lookahead/lookbehind, so
+# we'll look for 40 base64 characters, then whitelist
+# if they're embedded in a string of 41 base64, that is, 
+# without any delimiters. This make a false negative for, say:
+#     foo=+awsSecretAccessKeyisBase64=40characters
+# but god have mercy on anyone trying to get that to work
+[[rules]]
+	description = "AWS secret key regardless of labeling"
+	regex = '''.?[A-Za-z0-9\\+=]{40}.?'''
+	[[rules.whitelist]]
+		regex = '''[A-Za-z0-9\\+=]{41}'''
+		description = "41 base64 characters is not an AWS secret key"
+
 # Rules from original `leaky-repo.toml` v4.1.1
 # https://raw.githubusercontent.com/zricethezav/gitleaks/master/examples/leaky-repo.toml
 # with the following rule sets removed:

--- a/local.toml
+++ b/local.toml
@@ -225,5 +225,5 @@ title = "gitleaks config"
 
 [whitelist]
 	description = "image whitelists"
-	file = '''(.*?)(jpg|gif|doc|pdf|bin)$'''
+	file = '''(.*?)(jpg|gif|doc|pdf|bin|svg)$'''
 

--- a/local.toml
+++ b/local.toml
@@ -11,8 +11,6 @@ title = "gitleaks config"
 	regex = '''[\W\D]?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}[\W\D]?'''
 	tags = ["IPv4", "IP", "addresses"]
 	[[rules.whitelist]]
-		file = '''(.*)?svg$'''
-	[[rules.whitelist]]
 		regex = '''(169.254.169.254|127.0.0.\d+)'''
 
 # s3config copied from `leaky-repo.toml` upstream, but uncommented:
@@ -225,5 +223,5 @@ title = "gitleaks config"
 
 [whitelist]
 	description = "image whitelists"
-	file = '''(.*?)(jpg|gif|doc|pdf|bin|svg)$'''
+	files = ['''(.*?)(jpg|gif|doc|pdf|bin|svg)$''']
 

--- a/local.toml
+++ b/local.toml
@@ -10,35 +10,39 @@ title = "gitleaks config"
 	description = "IPv4 addresses"
 	regex = '''[\W\D]?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}[\W\D]?'''
 	tags = ["IPv4", "IP", "addresses"]
+	[[rules.whitelist]]
+		file = '''(.*)?svg$'''
+	[[rules.whitelist]]
+		regex = '''(169.254.169.254|127.0.0.\d+)'''
 
 # s3config copied from `leaky-repo.toml` upstream, but uncommented:
 [[rules]]
 	description = "s3config"
-  	regex = '''(?i)(dbpasswd|dbuser|dbname|dbhost|api_key|apikey|key|api|password|user|guid|hostname|pw|auth)(.{0,3})?([0-9a-zA-Z-_\/+!{}=]{4,120})'''
+	regex = '''(?i)(dbpasswd|dbuser|dbname|dbhost|api_key|apikey|key|api|password|user|guid|hostname|pw|auth)(.{0,3})?([0-9a-zA-Z-_\/+!{}=]{4,120})'''
 	fileNameRegex = '''(?i)s3cfg$'''
 
 [[rules]]
 	description = "yaml secrets"
-	regex = '''(?i)(password|enc.key|auth.pass): '''
-  	fileNameRegex = '''(?i)(\.yml|\.yaml)'''
+	regex = '''(?i)(password|enc.key|auth.pass):\s+(.*)'''
+	fileNameRegex = '''(?i)(\.yml|\.yaml)'''
 	tags = ["yaml"]
+	[[rules.whitelist]]
+		regex = '''(\(\(.*\)\)|\{\{.*\}\})'''
+		description = "ignore substituted values"
 
 [[rules]]
-	description = "Email"
-	regex = '''[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}'''
+	description = "Email except non-pii business email"
+	regex = '''(.{0,48}?)[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}'''
 	tags = ["email"]
 	[[rules.whitelist]]
-		file = '''(?i)bashrc'''
-		description = "ignore bashrc emails"
+		regex = '''(?i)@(cloud.gov|gsa.gov|github.com)'''
+		description = "ignore inquiries@cloud.gov etc"
 	[[rules.whitelist]]
-		file = '''(?i)support@cloud.gov'''
-		description = "ignore support@cloud.gov"
+		path = '''Godeps._workspace'''
+		description = "ignore included vendor files"
 	[[rules.whitelist]]
-		file = '''(?i)inquiries@cloud.gov'''
-		description = "ignore inquiries@cloud.gov"
-	[[rules.whitelist]]
-		file = '''(?i)[a-zA-Z0-9._%+-]+@github.com'''
-		description = "ignore github emails"
+		regex = '''(?i)(Author|Copyright|Contact)'''
+		description = "ignore explict author or copyright email"
 
 # Rules from original `leaky-repo.toml` v4.1.1
 # https://raw.githubusercontent.com/zricethezav/gitleaks/master/examples/leaky-repo.toml
@@ -171,13 +175,6 @@ title = "gitleaks config"
 	regex = '''(?i)(apikey|secret|key|api|password|pass|pw|host)=[0-9a-zA-Z-_.{}]{4,120}'''
 
 [[rules]]
-	description = "Port"
-	regex = '''(?i)port(.{0,4})?[0-9]{1,10}'''
-	[[rules.whitelist]]
-		regex = '''(?i)port '''
-		description = "ignore export "
-
-[[rules]]
 	description = "Generic Credential"
 	regex = '''(?i)(dbpasswd|dbuser|dbname|dbhost|api_key|apikey|secret|key|api|password|user|guid|hostname|pw|auth)(.{0,20})?['|"]([0-9a-zA-Z-_\/+!{}/=]{4,120})['|"]'''
 	tags = ["key", "API", "generic"]
@@ -191,6 +188,9 @@ title = "gitleaks config"
 	[[rules.whitelist]]
 		description = "AWS Manager ID"
 		regex = '''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}'''
+	[[rules.whitelist]]
+		description = "Ignore vendor deps and GoPkg"
+		path = '''(vendor.github|Godeps._workspace)'''
 
 [[rules]]
 	description = "High Entropy"

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -57,23 +57,7 @@ END
     testCommit $secrets_file
 }
 
-addFileWithCGEmails() {
-    local secrets_file="${REPO_PATH}/cgemailfile.md"
-    cat >${secrets_file} <<END
-No secrets in this file
-Email addresses like support@cloud.gov and inquiries@cloud.gov
-END
-    testCommit $secrets_file
-}
 
-addFileWithGithubEmails() {
-    local secrets_file="${REPO_PATH}/ghemailfile.md"
-    cat >${secrets_file} <<END
-No secrets in this file
-Email address like noreply@github.com or support@github.com
-END
-    testCommit $secrets_file
-}
 
 addFileWithSecretEmail() {
     local secrets_file="${REPO_PATH}/emailfile.md"
@@ -99,7 +83,7 @@ addFileWithIPv4() {
 
     cat >${secrets_file} <<END
 SHHHH... Secrets in this file
-Host: 127.0.0.1
+Host: 10.20.30.40
 END
     testCommit $secrets_file
 }
@@ -112,14 +96,14 @@ $1
 END
     testCommit $secrets_file
 }
-
+##########################
 # for development purposes
+##########################
 turnOffHooksGitleaks() {
     (cd $REPO_PATH && git config --local hooks.gitleaks false)
-    ./check_repos.sh $HOME check_hooks_gitleaks
+    ./check_repos.sh $REPO_PATH check_hooks_gitleaks
 }
 
-## remaining are for development purposes
 createPrecommitNoGitleaks() {
     (cd $REPO_PATH && mv .git/hooks/pre-commit.sample .git/hooks/pre-commit)
 }
@@ -136,4 +120,31 @@ createPrecommitOKGitLeaks() {
 echo special stuff
 /usr/local/bin/gitleaks
 END
+}
+addFileWithCGEmails() {
+    local secrets_file="${REPO_PATH}/cgemailfile.md"
+    cat >${secrets_file} <<END
+No secrets in this file
+Email addresses like support@cloud.gov and inquiries@cloud.gov
+END
+    testCommit $secrets_file
+}
+
+addFileWithGithubEmails() {
+    local secrets_file="${REPO_PATH}/ghemailfile.md"
+    cat >${secrets_file} <<END
+No secrets in this file
+Email address like noreply@github.com or support@github.com
+END
+    testCommit $secrets_file
+}
+
+addFileWithInterpolatedYamlPassword() {
+    local secrets_file="${REPO_PATH}/ok_secret.yml"
+    cat >${secrets_file} <<END
+No secrets in this file
+database_password: ((database_password))
+another_password:   {{foo_pass}}
+END
+    testCommit $secrets_file
 }


### PR DESCRIPTION

## Changes proposed in this pull request:

- Make development of rules in local.toml easier with guidance in development.bats and README
- Fix development.bats to run against local.toml
- Add more notes for Bug Bounty types
- First caulked test offers guidance on failure
- Move redundant tests to `development.bats` to keep `caulked.bats` short and fast
- Catch 40-char base64 strings as potential AWS secret key leaks
- Fix email pattern matching to not flag work email (gsa.gov, cloud.gov, github.com) or when preceded by "Author" or "Copyright" or "Contact"
- Remove Port matching
- Treat SVG as binaries
- Don't IPV4 match on 127.0.0.1 or 169.254.169.254
- Yaml with interpolation like `password: ((password))` is OK
- Skip stuff in `vendor/github` or `Godeps/_workspace`


## security considerations

No real secrets, better patterns with fewer false positives discourages sidestepping caulking