### PR TITLE
Fix ipv4 false positive

### DIFF
--- a/development.bats
+++ b/development.bats
@@ -87,3 +87,12 @@ END
     run testCommit $REPO_PATH
     [ ${status} -eq 0 ]
 }
+
+@test "Pass that Ubuntu version is not ipv4" {
+    cat > $REPO_PATH/foo.yml <<END
+=3.1.2-11ubuntu0.16.04.8
+END
+    run testCommit $REPO_PATH
+    [ ${status} -eq 0 ]
+}
+

--- a/local.toml
+++ b/local.toml
@@ -8,7 +8,7 @@ title = "gitleaks config"
 # and we can change match to (10|172|192). in the first octet.
 [[rules]]
 	description = "IPv4 addresses"
-	regex = '''[\W\D]?[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}[\W\D]?'''
+	regex = '''\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b'''
 	tags = ["IPv4", "IP", "addresses"]
 	[[rules.whitelist]]
 		regex = '''(169.254.169.254|127.0.0.\d+)'''


### PR DESCRIPTION
Borrowed from

https://www.oreilly.com/library/view/regular-expressions-cookbook/9780596802837/ch07s16.html

## Changes proposed in this pull request:

- Fix @ChrisMcGowan false positive

## security considerations

None. Tested also in regex101 

![image](https://user-images.githubusercontent.com/1211146/82364022-b5318e00-99dc-11ea-8eb8-c1a9eba50874.png)
