### PR TITLE
Fix IPv4 audit error

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,21 @@ pre-commit install
 git config --global core.hookspath "${hookspath}"
 ```
 
+## Incompatible gitleaks changes
+
+Sometimes gitleaks updates will have breaking changes, and you'll need to compare gitleaks
+between the current version and an older version. To install an older gitleaks version with `brew`:
+
+* Browse the [brew history for the gitleaks formula](https://github.com/Homebrew/homebrew-core/commits/master/Formula/gitleaks.rb)
+* Find the `commit` that matches the older version you want to roll back to
+* Then run: 
+  ```
+  wget https://raw.githubusercontent.com/Homebrew/homebrew-core/<commit>/Formula/gitleaks.rb
+  brew unlink gitleaks
+  brew install ./gitleaks.rb
+  ```
+* You'll now have the older version. 
+
 # Public domain
 
 This project is in the worldwide public domain. As stated in CONTRIBUTING:

--- a/development.bats
+++ b/development.bats
@@ -187,14 +187,23 @@ END
     [ ${status} -eq 0 ]
 }
 
-@test "if fails a suspect filename extension" {
+@test "it fails a suspect filename extension" {
     touch $REPO_PATH/foo.pem 
     run testCommit $REPO_PATH
     should_fail
 }
 
-@test "if fails a suspect filename" {
+@test "it fails a suspect filename" {
     touch $REPO_PATH/shadow
     run testCommit $REPO_PATH
     should_fail
 }
+
+@test "it fails a Sauce access key" {
+  cat > $REPO_PATH/travis.yml <<END
+    - SAUCE_ACCESS_KEY='39a45464-cb1d-4b8d-aa1f-83c7c04fa673'
+END
+    run testCommit $REPO_PATH
+    should_fail
+}
+

--- a/local.toml
+++ b/local.toml
@@ -12,7 +12,7 @@ title = "gitleaks config"
 	tags = ["IPv4", "IP", "addresses"]
 	[rules.allowlist] 
 		regexes = ['''(169.254.169.254|127.0.0.\d+|23.22.13.113)''', # 23.22.13.113 is gsa.gov
-		'''0\.(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){2}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)''' # OK to start w/ 0.
+		'''\b0\.(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){2}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b''' # OK to start w/ 0.
 		]
 
 # s3config copied from `leaky-repo.toml` upstream, but uncommented:


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fixed failing check for ipv4 by using `\b` on either side of the allowlist exception for ipv4-like strings that start with `0`
- Added a development test for Sauce access keys, no new patterns needed
- README on how to roll back to older GitLeak (which turned out to be a red herring)

:tophat: tip to @jfredrickson5 for pairing on this.

## security considerations

Enhancement with no downside. Content changes are patterns, tests ensure we're only reducing number of false positives.

