### PR TITLE
Only check for usernames in YML

### DIFF
--- a/development.bats
+++ b/development.bats
@@ -206,3 +206,12 @@ END
     should_fail
 }
 
+
+@test "it allows an inspec count of users" { 
+  cat > $REPO_PATH/inspec.rb <<END
+    user_count = input('admins').length + input('non-admins').length
+END
+    run testCommit $REPO_PATH
+    should_pass
+}
+

--- a/local.toml
+++ b/local.toml
@@ -172,12 +172,11 @@ title = "gitleaks config"
 [[rules]]
 	description = "Generic Username"
 	regex = '''(?i)(dbuser|user)(.{0,20})?['|"]([0-9a-zA-Z-_\/+!{}/=]{4,120})['|"]'''
-	file = '''ya?ml$'''
 	tags = ["key", "username", "generic"]
-#	[rules.allowlist]
-#		description = "A username in a terraform file is not a leak"
-#		regexes = ['''\w+?username\w+=''']
-#		files = 	['''\.tf$''']
+	[rules.allowlist]
+		description = "A username in a terraform file and programs is not a leak"
+		regexes = ['''\w+?username\w+=''']
+		files = 	['''\.(tf|rb|go|py)$''']
 
 [[rules]]
 	description = "Generic Credential"

--- a/local.toml
+++ b/local.toml
@@ -172,11 +172,12 @@ title = "gitleaks config"
 [[rules]]
 	description = "Generic Username"
 	regex = '''(?i)(dbuser|user)(.{0,20})?['|"]([0-9a-zA-Z-_\/+!{}/=]{4,120})['|"]'''
+	file = '''ya?ml$'''
 	tags = ["key", "username", "generic"]
-	[rules.allowlist]
-		description = "A username in a terraform file is not a leak"
-		regexes = ['''\w+?username\w+=''']
-		files = 	['''\.tf$''']
+#	[rules.allowlist]
+#		description = "A username in a terraform file is not a leak"
+#		regexes = ['''\w+?username\w+=''']
+#		files = 	['''\.tf$''']
 
 [[rules]]
 	description = "Generic Credential"


### PR DESCRIPTION
## Changes proposed in this pull request:

The existing Generic Username rule had gotten tripped up on the following Ruby code:
```
    user_count = input('admins').length + input('non-admins').length
```

so it seemed not to be a terribly useful rule.  Updating to have an exception for Python, Go, Ruby, Terraform instead. 

## security considerations

Reduces false positives, which is good.
