### PR TITLE
Re-add command to remove sekrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,13 @@ clean:
 	git config --global --unset hooks.gitleaks
 	git config --global --unset core.hooksPath
 
+clean_seekrets:
+	/bin/rm -rf ${GIT_SUPPORT_PATH}/seekret-rules
+	-git config --global --unset gitseekret.rulesenabled
+	-git config --global --unset gitseekret.rulespath
+	-git config --global --unset gitseekret.exceptionsfile
+	-git config --global --unset gitseekret.version
+
 hook pre-commit: ${GIT_SUPPORT_PATH}/hooks/pre-commit
 
 global_hooks:


### PR DESCRIPTION
## Changes proposed in this pull request:

The README refers to a clean_seekrets command that was removed in #42. Either the make command should be returned or the README should be updated! (I tried to do this myself but i don't have access rights)

## security considerations
[Note the any security considerations here, or make note of why there are none]
