### PR TITLE
Update the installation and upgrade steps for gitleaks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
-CAULKING_VERSION=1.2.0 2021-04-01
-GITLEAKS_VERSION=7.2.1
+CAULKING_VERSION=1.3.0 2021-12-21
+GITLEAKS_VERSION=7.6.1
+GITLEAKS_CHECKSUM=5e51a33beb6f358970815ecbbc40c6c28fb785ef6342da9a689713f99fece54f
 NOW=$(shell date)
 ME=$(shell whoami)
 
@@ -15,8 +16,8 @@ INSTALL_TARGETS= ${PATTERNS} ${PRECOMMIT} ${GITLEAKS}
 
 install: $(INSTALL_TARGETS) global_hooks
 
-audit: /usr/local/bin/bats /usr/local/bin/pcregrep ${GITLEAKS} $(INSTALL_TARGETS)
-	@test $$(gitleaks --version) =  ${GITLEAKS_VERSION} || make upgrade
+audit: /usr/local/bin/bats /usr/local/bin/pcregrep /usr/local/bin/wget ${GITLEAKS} $(INSTALL_TARGETS)
+	@test $$(gitleaks --version) = ${GITLEAKS_VERSION} || make upgrade
 	@echo ${CAULKING_VERSION}
 	@echo "${ME} / ${NOW}"
 	bats -p caulked.bats
@@ -56,13 +57,18 @@ ${GIT_SUPPORT_PATH} ${HOOKS}:
 /usr/local/bin/pcregrep:
 	brew install pcre
 
-/usr/local/bin/%:
-	brew install $(@F)
+/usr/local/bin/wget:
+	brew install wget
+
+/usr/local/bin/gitleaks:
+	wget https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks-darwin-amd64
+	mkdir -p ${HOME}/bin
+	mv gitleaks-darwin-amd64 ${HOME}/bin/gitleaks
+	chmod 755 ${HOME}/bin/gitleaks
+	ln -s ${HOME}/bin/gitleaks ${GITLEAKS}
 
 upgrade:
-	@echo Simplify this code once we are all back to 7.2.1 or higher.
-	brew rm gitleaks
-	brew install gitleaks
-	brew link gitleaks
+	brew uninstall gitleaks || rm -f ${GITLEAKS} && rm -f ${HOME}/bin/gitleaks
+	make ${GITLEAKS}
 
 FORCE:


### PR DESCRIPTION
This changeset modifies the `Makefile` script to download the `7.6.1` release of gitleaks directly so that we can continue to use it with our audits.  We will be creating a new PR to update our support of gitleaks to the latest version in the near future.

## Changes proposed in this pull request:
- Swaps out the installation steps to pull from GitHub directly to get the `7.6.1` version of gitleaks instead of using Homebrew

## Security considerations:
- This pins us to an older version of gitleaks for the moment, but it also allows our pre-commit hooks to properly function until we can account for all of the changes with the 8.x releases