### PR TITLE
Add exclusion from Generic Credentials tests for lock files

### DIFF
--- a/development.bats
+++ b/development.bats
@@ -240,3 +240,19 @@ END
     should_pass
 }
 
+@test "it excludes lockfiles from Generic Credential checks" {
+  cat > $REPO_PATH/yarn.lock <<END
+    "@hapi/boom@9.x.x", "@hapi/boom@^9.1.0":
+END
+    run testCommit $REPO_PATH
+    should_pass
+}
+
+@test "it excludes nested lockfiles from Generic Credential checks" {
+  mkdir -p $REPO_PATH/apps/foo 
+  cat > $REPO_PATH/apps/foo/yarn.lock <<END
+    "@hapi/boom@9.x.x", "@hapi/boom@^9.1.0":
+END
+    run testCommit $REPO_PATH
+    should_pass
+}

--- a/local.toml
+++ b/local.toml
@@ -188,6 +188,7 @@ title = "gitleaks config"
 			'''(?i)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]''',
 			'''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}''']
 		paths = ['''(vendor.github|Godeps._workspace)''']
+		files = ['''^(yarn.lock|package-lock.json|pnpm-lock.yaml)$''']
 
 [[rules]]
 	description = "High Entropy"


### PR DESCRIPTION
## Changes proposed in this pull request:
- Addresses #63 
- Adds exclusions from Generic Credential checks for lock files

This aims to eliminate a ton of false positives in yarn.lock files when new dependencies are added.

## Example
An entry such as

```json
"@hapi/boom@9.x.x", "@hapi/boom@^9.1.0":
  version "9.1.2"
  resolved "https://registry.yarnpkg.com/@hapi/boom/-/boom-9.1.2.tgz#48bd41d67437164a2d636e3b5bc954f8c8dc5e38"
  integrity sha512-uJEJtiNHzKw80JpngDGBCGAmWjBtzxDCz17A9NO2zCi8LLBlb5Frpq4pXwyN+2JQMod4pKz5BALwyneCgDg89Q==
  dependencies:
    "@hapi/hoek" "9.x.x"
```

results in
```json
{
        "line": "    \"@hapi/boom\" \"9.x.x\"",
        "lineNumber": 2,
        "offender": "api/boom\" \"9.x.x\"",
        "offenderEntropy": -1,
        "commit": "0000000000000000000000000000000000000000",
        "repo": "federalist-builder",
        "repoURL": "",
        "leakURL": "",
        "rule": "Generic Credential",
        "commitMessage": "",
        "author": "",
        "email": "",
        "file": "yarn.lock",
        "date": "1970-01-01T00:00:00Z",
        "tags": "key, API, generic"
}
```

## security considerations
Lockfiles are typically machine-generated and read and should never contain secrets.
