### PR TITLE
Remove unused flag

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -14,7 +14,7 @@ gitleaksEnabled=$(git config --bool hooks.gitleaks)
 # but you're actually trying to commit:
 #   database-pass: a-real-damn-password
 # then, you need to see the full output to realize your mistake
-cmd="$HOME/bin/gitleaks --unstaged --verbose --leaks-exit-code=1 --config-path=$HOME/.git-support/gitleaks.toml"
+cmd="$HOME/bin/gitleaks --verbose protect --config-path=$HOME/.git-support/gitleaks.toml"
 if [ $gitleaksEnabled == "true" ]; then
     $cmd
     status=$?


### PR DESCRIPTION
Previously, the gitleaks cmd used the `--unstaged` flag, which according to [this issue](https://github.com/zricethezav/gitleaks/issues/622#issuecomment-975848007) no longer works in recent versions of `gitleaks`. (The unstaged flag is not documented on current versions of gitleaks at all.) Instead, users are encouraged to use `gitleaks protect`.

## Changes proposed in this pull request:
- update gitleaks cmd so that using gitleaks will not fail with an `Error: unknown flag: --unstaged` error

## security considerations
According to the above issue, `gitleaks protect` should work properly. (Although I am no expert, and would love another set of eyes/opinion on this!)
