### PR TITLE
Update gitleaks to 8.8.4

### DIFF
--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -1,0 +1,14 @@
+name: Install and run audit tests
+
+on:
+  pull_request:
+
+jobs:
+  install_and_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install caulking
+        run: make
+
+      - name: Run audit tests
+        run: make audit

--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -21,7 +21,9 @@ jobs:
           restore-keys: brew-
 
       - name: Install caulking
-        run: make install
+        run: |
+          export TERM=screen-256color
+          make install
 
       - name: Run audit tests
         run: make audit

--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -21,9 +21,9 @@ jobs:
           restore-keys: brew-
 
       - name: Install caulking
-        run: |
-          export TERM=screen-256color
-          make install
+        run: make install
 
       - name: Run audit tests
-        run: make audit
+        run: |
+          export TERM=screen-256color
+          make audit

--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -5,12 +5,23 @@ on:
 
 jobs:
   install_and_audit:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-          
+
+      - name: Cache Homebrew packages
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-brew-lib
+        with:
+          path: |
+            ~/Library/Caches/Homebrew/pcre*
+            ~/Library/Caches/Homebrew/bats-core*
+          key: brew-${{ hashFiles('.github/brew-formulae') }}
+          restore-keys: brew-
+
       - name: Install caulking
-        run: make
+        run: make install
 
       - name: Run audit tests
         run: make audit

--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -15,8 +15,11 @@ jobs:
           cache-name: cache-brew-lib
         with:
           path: |
-            ~/Library/Caches/Homebrew/pcre*
-            ~/Library/Caches/Homebrew/bats-core*
+            /usr/local/Homebrew
+            /usr/local/Cellar
+            /usr/local/Frameworks
+            /usr/local/bin
+            /usr/local/opt
           key: ${{ runner.os }}-brew-${{ hashFiles('Makefile') }}
           restore-keys: ${{ runner.os }}-brew-
 

--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -26,4 +26,5 @@ jobs:
       - name: Run audit tests
         run: |
           export TERM=screen-256color
+          brew --cache
           make audit

--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -16,10 +16,12 @@ jobs:
         with:
           path: |
             /usr/local/Homebrew
-            /usr/local/Cellar
-            /usr/local/Frameworks
-            /usr/local/bin
-            /usr/local/opt
+            /usr/local/Cellar/bats*
+            /usr/local/Cellar/pcre*
+            /usr/local/bin/bats*
+            /usr/local/bin/pcre*
+            /usr/local/opt/bats*
+            /usr/local/opt/pcre*
           key: ${{ runner.os }}-brew-${{ hashFiles('Makefile') }}
           restore-keys: ${{ runner.os }}-brew-
 

--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -7,6 +7,8 @@ jobs:
   install_and_audit:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
+          
       - name: Install caulking
         run: make
 

--- a/.github/workflows/install-audit.yml
+++ b/.github/workflows/install-audit.yml
@@ -17,8 +17,8 @@ jobs:
           path: |
             ~/Library/Caches/Homebrew/pcre*
             ~/Library/Caches/Homebrew/bats-core*
-          key: brew-${{ hashFiles('.github/brew-formulae') }}
-          restore-keys: brew-
+          key: ${{ runner.os }}-brew-${{ hashFiles('Makefile') }}
+          restore-keys: ${{ runner.os }}-brew-
 
       - name: Install caulking
         run: make install

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ INSTALL_TARGETS= ${PATTERNS} ${PRECOMMIT} ${GITLEAKS}
 install: $(INSTALL_TARGETS) global_hooks
 
 audit: /usr/local/bin/bats /usr/local/bin/pcregrep ${GITLEAKS} $(INSTALL_TARGETS)
-	@test $$(${GITLEAKS} version) = "${GITLEAKS_VERSION}" || ( echo "ERROR -- RUN: 'make install'" && false )
+	@test "$$(${GITLEAKS} version)" = "${GITLEAKS_VERSION}" || ( echo "ERROR -- RUN: 'make clean install'" && false )
 	@echo ${CAULKING_VERSION}
 	@echo "${ME} / ${NOW}"
 	bats -p caulked.bats
@@ -28,6 +28,7 @@ clean:
 	/bin/rm -rf ${GIT_SUPPORT_PATH}
 	git config --global --unset hooks.gitleaks
 	git config --global --unset core.hooksPath
+	/bin/rm -rf ${GITLEAKS}
 
 clean_seekrets:
 	/bin/rm -rf ${GIT_SUPPORT_PATH}/seekret-rules

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 CAULKING_VERSION=1.3.1 2022-01-16
-GITLEAKS_VERSION=7.6.1
-GITLEAKS_CHECKSUM=5e51a33beb6f358970815ecbbc40c6c28fb785ef6342da9a689713f99fece54f
+GITLEAKS_VERSION=8.8.4
+GITLEAKS_ARTIFACT="gitleaks_${GITLEAKS_VERSION}_darwin_x64.tar.gz"
+GITLEAKS_CHECKSUM=509430dada69ee4314068847a8a424d4102defc23fd5714330d36366796feef7
 NOW=$(shell date)
 ME=$(shell whoami)
 
@@ -17,7 +18,7 @@ INSTALL_TARGETS= ${PATTERNS} ${PRECOMMIT} ${GITLEAKS}
 install: $(INSTALL_TARGETS) global_hooks
 
 audit: /usr/local/bin/bats /usr/local/bin/pcregrep ${GITLEAKS} $(INSTALL_TARGETS)
-	@test $$(${GITLEAKS} --version) = "v.${GITLEAKS_VERSION}" || ( echo "ERROR -- RUN: 'make install'" && false )
+	@test $$(${GITLEAKS} version) = "${GITLEAKS_VERSION}" || ( echo "ERROR -- RUN: 'make install'" && false )
 	@echo ${CAULKING_VERSION}
 	@echo "${ME} / ${NOW}"
 	bats -p caulked.bats
@@ -49,7 +50,7 @@ ${PRECOMMIT}: pre-commit.sh ${HOOKS}
 	install -m 0755 -cv $< $@
 
 ${GIT_SUPPORT_PATH} ${HOOKS}:
-	mkdir -p $@ 
+	mkdir -p $@
 
 /usr/local/bin/bats:
 	brew install bats-core
@@ -59,7 +60,8 @@ ${GIT_SUPPORT_PATH} ${HOOKS}:
 
 ${HOME}/bin/gitleaks:
 	mkdir -p ${HOME}/bin
-	curl -o $@ -L https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks-darwin-amd64
+	curl -o ${HOME}/bin/${GITLEAKS_ARTIFACT} -L https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_VERSION}/${GITLEAKS_ARTIFACT}
+	tar -xvzf ${HOME}/bin/${GITLEAKS_ARTIFACT} --directory ${HOME}/bin
 	chmod 755 $@
 
 upgrade:

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ CAULKING_VERSION=1.3.1 2022-01-16
 GITLEAKS_VERSION=8.8.4
 GITLEAKS_ARTIFACT="gitleaks_${GITLEAKS_VERSION}_darwin_x64.tar.gz"
 GITLEAKS_CHECKSUM=509430dada69ee4314068847a8a424d4102defc23fd5714330d36366796feef7
+GITLEAKS_DOWNLOAD_DIR="${HOME}/bin/gitleaks-files"
 NOW=$(shell date)
 ME=$(shell whoami)
 
@@ -58,10 +59,12 @@ ${GIT_SUPPORT_PATH} ${HOOKS}:
 /usr/local/bin/pcregrep:
 	brew install pcre
 
-${HOME}/bin/gitleaks:
-	mkdir -p ${HOME}/bin
-	curl -o ${HOME}/bin/${GITLEAKS_ARTIFACT} -L https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_VERSION}/${GITLEAKS_ARTIFACT}
-	tar -xvzf ${HOME}/bin/${GITLEAKS_ARTIFACT} --directory ${HOME}/bin
+${GITLEAKS}:
+	mkdir -p ${GITLEAKS_DOWNLOAD_DIR}
+	curl -o ${GITLEAKS_DOWNLOAD_DIR}/${GITLEAKS_ARTIFACT} -L https://github.com/zricethezav/gitleaks/releases/download/v${GITLEAKS_VERSION}/${GITLEAKS_ARTIFACT}
+	tar -xvzf ${GITLEAKS_DOWNLOAD_DIR}/${GITLEAKS_ARTIFACT} --directory ${GITLEAKS_DOWNLOAD_DIR}
+	cp ${GITLEAKS_DOWNLOAD_DIR}/gitleaks ${GITLEAKS}
+	rm -rf ${GITLEAKS_DOWNLOAD_DIR}
 	chmod 755 $@
 
 upgrade:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@ Goals:
 
 ## Installation notes
 
-This assumes you are on MacOS with HomeBrew installed. `make install` will brew install `gitleaks`. The install will:
+`make install` will install `gitleaks`. The install will:
 
 * install `gitleaks`
+  - **Note:** Only `gitleaks` version 8 is currently supported.
 * add a global `pre-commit` hook to `$HOME/.git-support/hooks/pre-commit`
 * add the configuration with patterns to `$HOME/.git-support/gitleaks.toml`
 
@@ -70,7 +71,7 @@ You have a couple of choices:
 * Submit an issue to this repo, and then ignore `gitleaks` _temporarily_ with:
 
         git config --local hooks.gitleaks false
-        git commit -m "message" 
+        git commit -m "message"
         git config --local hooks.gitleaks true
 
 You may want to add function to your `.bashrc` profile like:
@@ -109,7 +110,7 @@ To work on patterns, add test cases to `development.bats`, update patterns in `l
 run `bats development.bats`.  Here are some shortcuts
 
 - `make hook`: update `~/.git-support/hooks/pre-commit` from local `pre-commit.sh`
-- `make patterns`: update the `gitleaks` configuration in `~/.git-support/gitleaks.toml` from local `local.toml` 
+- `make patterns`: update the `gitleaks` configuration in `~/.git-support/gitleaks.toml` from local `local.toml`
 - `make audit`: see that everything work together.
 
 ## Testing bats tests
@@ -121,8 +122,8 @@ example:
 ``` sh
 bash # start a new shell
 source test_helper.bash # load all the helper functions
-setup 
-addFileWithNoSecrets # do the failing thing 
+setup
+addFileWithNoSecrets # do the failing thing
 echo $?
 ^D
 ```
@@ -136,7 +137,7 @@ The following rule sets helped inform our gitleaks.toml:
 
 ## What about other hooks? Will they still run?
 
-Yes. Caulking runs your other precommit hooks automatically. 
+Yes. Caulking runs your other precommit hooks automatically.
 
 Note: if you're using [pre-commit](https://pre-commit.com/) to manage pre-commit hooks, you'll likely get an error like this when running `pre-commit install`:
 ```
@@ -158,13 +159,13 @@ between the current version and an older version. To install an older gitleaks v
 
 * Browse the [brew history for the gitleaks formula](https://github.com/Homebrew/homebrew-core/commits/master/Formula/gitleaks.rb)
 * Find the `commit` that matches the older version you want to roll back to
-* Then run: 
+* Then run:
   ```
   wget https://raw.githubusercontent.com/Homebrew/homebrew-core/<commit>/Formula/gitleaks.rb
   brew unlink gitleaks
   brew install ./gitleaks.rb
   ```
-* You'll now have the older version. 
+* You'll now have the older version.
 
 # Public domain
 

--- a/caulked.bats
+++ b/caulked.bats
@@ -25,6 +25,11 @@ load test_helper
     echo ${lines[6]} | grep -q "no leaks found"
 }
 
+@test "leak prevention catches unstaged aws secrets in test repo" {
+    run unstagedFileWithAwsSecrets
+    [ ${status} -eq 1 ]
+}
+
 @test "leak prevention catches aws secrets in test repo" {
     run addFileWithAwsSecrets
     [ ${status} -eq 1 ]

--- a/caulked.bats
+++ b/caulked.bats
@@ -11,10 +11,10 @@
 #              make clean_gitleaks install`
 # Running Tests:
 #   make audit
-# 
+#
 # Development note: These tests all assume that your root
 # ~/.git-support/gitleaks.toml are up to date. If you're testing
-# `local.toml` then use `development.bats` (or use `make patterns` 
+# `local.toml` then use `development.bats` (or use `make patterns`
 # before `make audit`)
 
 load test_helper
@@ -22,7 +22,7 @@ load test_helper
 @test "leak prevention allows plain text, check 'git config --global -l' on failure" {
     run addFileWithNoSecrets
     [ ${status} -eq 0 ]
-    echo ${lines[2]} | grep -q "No leaks found"
+    echo ${lines[6]} | grep -q "no leaks found"
 }
 
 @test "leak prevention catches aws secrets in test repo" {
@@ -65,7 +65,7 @@ load test_helper
 }
 
 @test "the ~/.aws directory is free of AWS keys" {
-  if [ -d ~/.aws ]; then 
+  if [ -d ~/.aws ]; then
     run grep -rq 'AKIA' $HOME/.aws
     [ ${status} -eq 1 ]
   else

--- a/caulked.bats
+++ b/caulked.bats
@@ -79,6 +79,9 @@ load test_helper
 }
 
 @test "git configuration uses a @gsa.gov email" {
+    if [ $CI = 'true' ]; then
+        skip "Skipping test in CI"
+    fi
     ./check_repos.sh $HOME check_user_email >&3
 }
 

--- a/development.bats
+++ b/development.bats
@@ -15,7 +15,7 @@ load test_helper
 
 # override testCommit to use local.toml in development
 testCommit() {
-    gitleaks --leaks-exit-code=1 --config-path=./local.toml --path=${REPO_PATH} --unstaged
+    gitleaks protect --config=./local.toml --path=${REPO_PATH} --unstaged
 }
 
 # Trying new `should` helper functions to aid

--- a/development.bats
+++ b/development.bats
@@ -2,7 +2,7 @@
 #
 # To keep `make audit` runs short with `caulked.bats`, this file
 # includes the rules for `allow`.  Also includes tests
-# that only make sense during development on the 
+# that only make sense during development on the
 # developers system
 
 # Bug bounty folks: Any apparent keys or passwords are just test strings
@@ -15,7 +15,7 @@ load test_helper
 
 # override testCommit to use local.toml in development
 testCommit() {
-    gitleaks protect --config=./local.toml --path=${REPO_PATH} --unstaged
+    gitleaks protect --config=./local.toml --source=${REPO_PATH} --staged
 }
 
 # Trying new `should` helper functions to aid
@@ -187,7 +187,7 @@ END
 }
 
 @test "it fails a suspect filename extension" {
-    touch $REPO_PATH/foo.pem 
+    touch $REPO_PATH/foo.pem
     run testCommit $REPO_PATH
     should_fail
 }
@@ -232,7 +232,7 @@ END
     should_fail
 }
 
-@test "it allows an inspec count of users" { 
+@test "it allows an inspec count of users" {
   cat > $REPO_PATH/inspec.rb <<END
     user_count = input('admins').length + input('non-admins').length
 END
@@ -249,7 +249,7 @@ END
 }
 
 @test "it excludes nested lockfiles from Generic Credential checks" {
-  mkdir -p $REPO_PATH/apps/foo 
+  mkdir -p $REPO_PATH/apps/foo
   cat > $REPO_PATH/apps/foo/yarn.lock <<END
     "@hapi/boom@9.x.x", "@hapi/boom@^9.1.0":
 END

--- a/local.toml
+++ b/local.toml
@@ -10,7 +10,7 @@ title = "gitleaks config"
 	description = "IPv4 addresses"
 	regex = '''\b(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b'''
 	tags = ["IPv4", "IP", "addresses"]
-	[rules.allowlist] 
+	[rules.allowlist]
 		regexes = ['''(169.254.169.254|127.0.0.\d+|23.22.13.113)''', # 23.22.13.113 is gsa.gov
 		'''\b0\.(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){2}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\b''' # OK to start w/ 0.
 		]
@@ -19,12 +19,12 @@ title = "gitleaks config"
 [[rules]]
 	description = "s3config"
 	regex = '''(?i)(dbpasswd|dbuser|dbname|dbhost|api_key|apikey|key|api|password|user|guid|hostname|pw|auth)(.{0,3})?([0-9a-zA-Z-_\/+!{}=]{4,120})'''
-	file = '''(?i)s3cfg$'''
+	path = '''(?i)s3cfg$'''
 
 [[rules]]
 	description = "yaml secrets"
 	regex = '''(?i)(password|enc.key|auth.pass):\s+(.*)'''
-	file = '''(?i)(\.yml|\.yaml)'''
+	path = '''(?i)(\.yml|\.yaml)'''
 	tags = ["yaml"]
 	[rules.allowlist]
 		description = "ignore substituted values and examples"
@@ -193,11 +193,9 @@ title = "gitleaks config"
 [[rules]]
 	description = "High Entropy"
 	regex = '''[0-9a-zA-Z-_!{}/=]{4,120}'''
-	file = '''(?i)(dump.sql|high-entropy-misc.txt)$'''
+	path = '''(?i)(dump.sql|high-entropy-misc.txt)$'''
 	tags = ["entropy"]
-	[[rules.Entropies]]
-		Min = "4.3"
-		Max = "7.0"
+	entropy = 4.3
 	[rules.allowlist]
 		files = ['''(pem|ppk|env)$''']
 		paths = ['''(.*)?ssh''']
@@ -206,10 +204,8 @@ title = "gitleaks config"
 	description = "Potential bash var"
 	regex='''(?i)(=)([0-9a-zA-Z-_!{}=]{4,120})'''
 	tags = ["key", "bash", "API", "generic"]
-	[[rules.Entropies]]
-		Min = "3.5"
-		Max = "4.5"
-		Group = "1"
+	entropy = 3.5
+	secretGroup = 1
 
 [[rules]]
 	description = "WP-Config"
@@ -218,12 +214,12 @@ title = "gitleaks config"
 
 [[rules]]
 	description = "File name extensions of credentials"
-	file = '''(?i)\.(pgpass|pem|key)'''
+	path = '''(?i)\.(pgpass|pem|key)'''
 	tags = ["file"]
 
 [[rules]]
 	description = "File names of credentials"
-	file = '''(?i)^(id_rsa|passwd|pgpass|shadow)'''
+	path = '''(?i)^(id_rsa|passwd|pgpass|shadow)'''
 
 [allowlist]
 	description = "image allowlists"

--- a/local.toml
+++ b/local.toml
@@ -176,7 +176,7 @@ title = "gitleaks config"
 	[rules.allowlist]
 		description = "A username in a terraform file and programs is not a leak"
 		regexes = ['''\w+?username\w+=''']
-		files = 	['''\.(tf|rb|go|py|js)$''']
+		paths = ['''\.(tf|rb|go|py|js)$''']
 
 [[rules]]
 	description = "Generic Credential"
@@ -187,8 +187,7 @@ title = "gitleaks config"
 		regexes = ['''xox[baprs]-([0-9a-zA-Z]{10,48})''',
 			'''(?i)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]''',
 			'''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}''']
-		paths = ['''(vendor.github|Godeps._workspace)''']
-		files = ['''^(yarn.lock|package-lock.json|pnpm-lock.yaml)$''']
+		paths = ['''(vendor.github|Godeps._workspace)''', '''^(yarn.lock|package-lock.json|pnpm-lock.yaml)$''']
 
 [[rules]]
 	description = "High Entropy"
@@ -197,8 +196,10 @@ title = "gitleaks config"
 	tags = ["entropy"]
 	entropy = 4.3
 	[rules.allowlist]
-		files = ['''(pem|ppk|env)$''']
-		paths = ['''(.*)?ssh''']
+		paths = [
+			'''(pem|ppk|env)$''',
+			'''(.*)?ssh'''
+		]
 
 [[rules]]
 	description = "Potential bash var"
@@ -214,7 +215,7 @@ title = "gitleaks config"
 
 [[rules]]
 	description = "File name extensions of credentials"
-	path = '''(?i)\.(pgpass|pem|key)'''
+	paths = '''(?i)\.(pgpass|pem|key)'''
 	tags = ["file"]
 
 [[rules]]
@@ -223,5 +224,5 @@ title = "gitleaks config"
 
 [allowlist]
 	description = "image allowlists"
-	files = ['''(.*?)(jpg|gif|doc|pdf|bin|svg)$''', '''development.bats''', '''caulked.bats''', '''local.toml''']
+	paths = ['''(.*?)(jpg|gif|doc|pdf|bin|svg)$''', '''development.bats''', '''caulked.bats''', '''local.toml''']
 	regexes	= ['''CHANGEME|changeme|feedabee|EXAMPLE|23.22.13.113|1234567890''']

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 
 git_dir=$(git rev-parse --git-dir)
 if [ -f "$git_dir/hooks/pre-commit" ]; then
@@ -14,7 +14,7 @@ gitleaksEnabled=$(git config --bool hooks.gitleaks)
 # but you're actually trying to commit:
 #   database-pass: a-real-damn-password
 # then, you need to see the full output to realize your mistake
-cmd="$HOME/bin/gitleaks --unstaged --verbose --leaks-exit-code=1 --config-path=$HOME/.git-support/gitleaks.toml"
+cmd="$HOME/bin/gitleaks protect --config=$HOME/.git-support/gitleaks.toml --verbose -l debug"
 if [ $gitleaksEnabled == "true" ]; then
     $cmd
     status=$?
@@ -23,12 +23,12 @@ if [ $gitleaksEnabled == "true" ]; then
 Error: gitleaks has detected sensitive information in your changes.
 For examples use: CHANGEME|changeme|feedabee|EXAMPLE|23.22.13.113|1234567890
 If you know what you are doing you can disable this check using:
-    git config --local hooks.gitleaks false; 
-    git commit ....; 
-    git config --local hooks.gitleaks true; 
+    git config --local hooks.gitleaks false;
+    git commit ....;
+    git config --local hooks.gitleaks true;
 EOF
         exit 1
-    else 
+    else
         exit $status
     fi
 fi

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh 
+#!/bin/sh
 
 git_dir=$(git rev-parse --git-dir)
 if [ -f "$git_dir/hooks/pre-commit" ]; then
@@ -14,7 +14,7 @@ gitleaksEnabled=$(git config --bool hooks.gitleaks)
 # but you're actually trying to commit:
 #   database-pass: a-real-damn-password
 # then, you need to see the full output to realize your mistake
-cmd="$HOME/bin/gitleaks --verbose protect --config-path=$HOME/.git-support/gitleaks.toml"
+cmd="$HOME/bin/gitleaks protect --staged --config=$HOME/.git-support/gitleaks.toml --verbose"
 if [ $gitleaksEnabled == "true" ]; then
     $cmd
     status=$?
@@ -23,12 +23,12 @@ if [ $gitleaksEnabled == "true" ]; then
 Error: gitleaks has detected sensitive information in your changes.
 For examples use: CHANGEME|changeme|feedabee|EXAMPLE|23.22.13.113|1234567890
 If you know what you are doing you can disable this check using:
-    git config --local hooks.gitleaks false; 
-    git commit ....; 
-    git config --local hooks.gitleaks true; 
+    git config --local hooks.gitleaks false;
+    git commit ....;
+    git config --local hooks.gitleaks true;
 EOF
         exit 1
-    else 
+    else
         exit $status
     fi
 fi

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/sh 
 
 git_dir=$(git rev-parse --git-dir)
 if [ -f "$git_dir/hooks/pre-commit" ]; then
@@ -14,7 +14,7 @@ gitleaksEnabled=$(git config --bool hooks.gitleaks)
 # but you're actually trying to commit:
 #   database-pass: a-real-damn-password
 # then, you need to see the full output to realize your mistake
-cmd="$HOME/bin/gitleaks protect --config=$HOME/.git-support/gitleaks.toml --verbose --staged"
+cmd="$HOME/bin/gitleaks --unstaged --verbose --leaks-exit-code=1 --config-path=$HOME/.git-support/gitleaks.toml"
 if [ $gitleaksEnabled == "true" ]; then
     $cmd
     status=$?
@@ -23,12 +23,12 @@ if [ $gitleaksEnabled == "true" ]; then
 Error: gitleaks has detected sensitive information in your changes.
 For examples use: CHANGEME|changeme|feedabee|EXAMPLE|23.22.13.113|1234567890
 If you know what you are doing you can disable this check using:
-    git config --local hooks.gitleaks false;
-    git commit ....;
-    git config --local hooks.gitleaks true;
+    git config --local hooks.gitleaks false; 
+    git commit ....; 
+    git config --local hooks.gitleaks true; 
 EOF
         exit 1
-    else
+    else 
         exit $status
     fi
 fi

--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -14,7 +14,7 @@ gitleaksEnabled=$(git config --bool hooks.gitleaks)
 # but you're actually trying to commit:
 #   database-pass: a-real-damn-password
 # then, you need to see the full output to realize your mistake
-cmd="$HOME/bin/gitleaks protect --config=$HOME/.git-support/gitleaks.toml --verbose -l debug"
+cmd="$HOME/bin/gitleaks protect --config=$HOME/.git-support/gitleaks.toml --verbose --staged"
 if [ $gitleaksEnabled == "true" ]; then
     $cmd
     status=$?

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -22,6 +22,11 @@ testCommit() {
     (cd ${REPO_PATH} && git commit -m 'test commit')
 }
 
+testUnstagedCommit() {
+    filename=$1
+    (cd ${REPO_PATH} && git commit -m 'test commit')
+}
+
 setup() {
     setupGitRepo
 }
@@ -36,6 +41,16 @@ addFileWithNoSecrets() {
     touch "${filename}"
     echo "Just a plain old file" >> "${filename}"
     testCommit $filename
+}
+
+unstagedFileWithAwsSecrets() {
+    local secrets_file="${REPO_PATH}/unstaged-secretsfile.md"
+
+    cat >${secrets_file} <<END
+SHHHH... Secrets in this file
+aws_secret_access_key = WT8ftNba7siVx5UOoGzJSyd82uNCZAC8LCllzcWp
+END
+    testUnstagedCommit $secrets_file
 }
 
 addFileWithAwsSecrets() {

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -2,7 +2,7 @@
 
 # Bug Bounty and Hackerone Folks: No need to report this file. The
 # apparent keys below are all test data used to
-# ensure our leak prevention tools are working. 
+# ensure our leak prevention tools are working.
 
 BATS_TMPDIR=${BATS_TMPDIR:-/tmp}     # set default if sourcing from cli
 REPO_PATH=$(mktemp -d "${BATS_TMPDIR}/gittest.XXXXXX")


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update `Makefile` to download and install `gitleaks` v8.8.4
- Update tests for compatibility with `gitleaks` v8
  - Added test for committing an unstaged file with secrets to ensure that we avoid regressions
- Update `local.toml` configuration with `gitleaks` v8, which has some fairly noteworthy changes in the configuration of rules:
  - `file` is now `path`
  - `rules.entropies.Min` is now just `entropy`. 
  - Setting a maximum entropy seems to no longer be supported?
  - `rules.entropies.Group` is now `secretGroup`
- Add Github action workflow to run our `make audit` tests in CI

## security considerations

Given the upgraded version of `gitleaks` and significant changes to its configuration and invocation, we want to make sure that there are no regressions in our detection. I assume that the unit tests are supposed to protect against regressions, but is there anything else that we should do here?
