### PR TITLE
use SKIP=gitleaks flag instead of configs 

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
 
 git_dir=$(git rev-parse --git-dir)
+
 if [ -f "$git_dir/hooks/pre-commit" ]; then
     set -e
     "$git_dir/hooks/pre-commit" "$@"
     set +e
 fi
 
-gitleaksEnabled=$(git config --bool hooks.gitleaks)
-# Running _without_ `--redact` is safer.  Here's wny:
-# Suppose you think you're committing `example.yml`:
-#   database-pass: example-password
-# but you're actually trying to commit:
-#   database-pass: a-real-damn-password
-# then, you need to see the full output to realize your mistake
-cmd="$HOME/bin/gitleaks protect --staged --config=$HOME/.git-support/gitleaks.toml --verbose"
-if [ $gitleaksEnabled == "true" ]; then
+run_gitleaks() {
+    # Running _without_ `--redact` is safer in a local development
+    # env, as you need unobfuscated feedback on whether you're 
+    # committing a real password, or an example one.
+    cmd="$HOME/bin/gitleaks protect --staged --config=$HOME/.git-support/gitleaks.toml --verbose"
     $cmd
     status=$?
     if [ $status -eq 1 ]; then
@@ -23,12 +20,34 @@ if [ $gitleaksEnabled == "true" ]; then
 Error: gitleaks has detected sensitive information in your changes.
 For examples use: CHANGEME|changeme|feedabee|EXAMPLE|23.22.13.113|1234567890
 If you know what you are doing you can disable this check using:
-    git config --local hooks.gitleaks false;
-    !-2  # command -2 in your history
-    git config --local hooks.gitleaks true;
+    SKIP=gitleaks $*
 EOF
         exit 1
     else
         exit $status
     fi
+}
+
+skip_gitleaks() {
+    echo "Sleeping for 5 seconds while you ponder your choices"
+    for i in 1 2 3 4 5; do
+      echo -n ". "
+      sleep 1
+    done
+    read -p "Are you sure about skipping gitleaks? " yn
+    case $in in
+        [Yy]*) exit 0;;
+        *)     exit 1;;
+    esac
+}
+
+gitleaksEnabled=$(git config --bool hooks.gitleaks)
+if [ "$gitleaksEnabled" = "false" ]; then
+    echo "You're skipping gitleaks hooks.gitleaks if false"
+    skip_gitleaks
+elif [ "$SKIP" = "gitleaks" ]; then
+    echo "You're skipping gitleaks check since SKIP=gitleaks"
+    skip_gitleaks
+else
+    run_gitleaks
 fi


### PR DESCRIPTION
## Changes proposed in this pull request:
-
- Reorg precommit into two functions, run_gitleaks and skip_gitleaks
- Add logic to skip if either the config is off, or SKIP is set
- Make it modestly annoying to SKIP

## security considerations
This needs careful review to make sure we're not accidentally skipping gitleaks. But should improve the DX here.
