### PR TITLE
ignore composer.lock file for certain rules

### DIFF
--- a/local.toml
+++ b/local.toml
@@ -37,7 +37,7 @@ title = "gitleaks config"
 	[rules.allowlist]
 		regexes = ['''(?i)@(cloud.gov|gsa.gov|github.com)''',
 			'''(?i)(Author|Copyright|Contact)''']
-		paths = ['''Godeps._workspace''']
+		paths = ['''Godeps._workspace''', '''(composer.lock)$''']
 
 # Rules from original `leaky-repo.toml` v4.1.1
 # https://raw.githubusercontent.com/zricethezav/gitleaks/master/examples/leaky-repo.toml
@@ -188,7 +188,7 @@ title = "gitleaks config"
 		regexes = ['''xox[baprs]-([0-9a-zA-Z]{10,48})''',
 			'''(?i)(.{0,20})?['"][0-9a-f]{32}-us[0-9]{1,2}['"]''',
 			'''(A3T[A-Z0-9]|AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)[A-Z0-9]{16}''']
-		paths = ['''(vendor.github|Godeps._workspace)''', '''(yarn.lock|package-lock.json|pnpm-lock.yaml)$''']
+		paths = ['''(vendor.github|Godeps._workspace)''', '''(yarn.lock|package-lock.json|pnpm-lock.yaml|composer.lock)$''']
 
 [[rules]]
 	description = "High Entropy"


### PR DESCRIPTION
## Changes proposed in this pull request:

`composer.lock` is an auto-generated file for PHP dependency management via composer. It's the PHP equivalent of `package-lock.json` in Node or `Gemfile.lock` in Ruby

Since it's an auto-generated file that we don't control the contents of, I don't think we need to scan it, at least for certain rules.

For example, without these changes I'm getting a lot of exceptions for the `Email except non-pii business email` rule like:

```text
        "Match": "                    \"email\": \"[jlogsdon@php.net](mailto:jlogsdon@php.net)",
```

And for the  `Generic Credential` rule like:

```text
        "Match": "api-version\": \"2.3.0\"",
```

So this PR adds `composer.lock` to be ignored for those rules, which I can confirm allowed me to commit my `compser.lock` file locally with these changes.

## security considerations

We are updating the ignore patterns for GitLeaks, so we should agree that we are not ignoring potentially dangerous changes in `composer.lock` files. However, since this file is auto-generated and not edited manually, I don't think that such concerns apply here.
