### PR TITLE
Update git hook tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Clone the repository with the `--recurse-submodules` flag. Or, if you have alrea
 `make install` will install `gitleaks`. The install will:
 
 * install `gitleaks`
-  - **Note:** Only `gitleaks` version 8 is currently supported.
+  * **Note:** Only `gitleaks` version 8 is currently supported.
 * add a global `pre-commit` hook to `$HOME/.git-support/hooks/pre-commit`
 * add the configuration with patterns to `$HOME/.git-support/gitleaks.toml`
 
@@ -23,7 +23,7 @@ You now have the gitleaks pre-commit hook enabled globally.
 
 To get rid of `git-seekrets` configuration, run `make clean_seekrets`
 
-## Bug warning!
+## Bug warning
 
 If you get the error `reference not found` on a new repository, be sure you've run `brew upgrade gitleaks` to install version 4.1.1 or later.
 
@@ -47,19 +47,19 @@ You have installed gitleaks and our patterns, and you've verified that all of yo
 
 If you get a `git commit` error message like this:
 
-```
+```json
 {
-	"line": "Juana M. is at juana@example.com",
-	"offender": "javier@example.com",
-	"commit": "0000000000000000000000000000000000000000",
-	"repo": "gittest.ffqOwg",
-	"rule": "Email",
-	"commitMessage": "***STAGED CHANGES***",
-	"author": "",
-	"email": "",
-	"file": "secretsfile.md",
-	"date": "1970-01-01T00:00:00Z",
-	"tags": "email"
+    "line": "Juana M. is at juana@example.com",
+    "offender": "javier@example.com",
+    "commit": "0000000000000000000000000000000000000000",
+    "repo": "gittest.ffqOwg",
+    "rule": "Email",
+    "commitMessage": "***STAGED CHANGES***",
+    "author": "",
+    "email": "",
+    "file": "secretsfile.md",
+    "date": "1970-01-01T00:00:00Z",
+    "tags": "email"
 }
 ```
 
@@ -72,87 +72,63 @@ You have a couple of choices:
 * Submit a PR to improve our patterns (guidance forthcoming)
 * Submit an issue to this repo, and then ignore `gitleaks` _temporarily_ with:
 
-        git config --local hooks.gitleaks false
-        git commit -m "message"
-        git config --local hooks.gitleaks true
-
-You may want to add function to your `.bashrc` profile like:
-
-```bash
-gitforce() {
-    read -p "You are about to commit a potential secret. Are you sure (y/n)? " -n 1 -r
-        echo    # (optional) move to a new line
-    if [[ $REPLY =~ ^[Yy]$ ]]
-    then
-        git config --local hooks.gitleaks false
-        git commit -m "$@" || true
-        git config --local hooks.gitleaks true
-    fi
-}
+```shell
+    SKIP=gitleaks git commit -m "message"
 ```
 
-Or, if you are using ZSH for your shell, add this to your `.zshrc` file:
-
-```zsh
-gitforce() {
-    read "confirm?You are about to commit a potential secret. Are you sure (y/n)?"
-        echo    # (optional) move to a new line
-    if [[ "$confirm" =~ ^[Yy]$ ]]
-    then
-        git config --local hooks.gitleaks false
-        git commit -m "$@" || true
-        git config --local hooks.gitleaks true
-    fi
-}
-```
-
-# Development tips
+## Development tips
 
 To work on patterns, add test cases to `development.bats`, update patterns in `local.toml` then
-run `bats development.bats`.  Here are some shortcuts
+run `bats development.bats`.  Here are some shortcuts:
 
-- `make hook`: update `~/.git-support/hooks/pre-commit` from local `pre-commit.sh`
-- `make patterns`: update the `gitleaks` configuration in `~/.git-support/gitleaks.toml` from local `local.toml`
-- `make audit`: see that everything work together.
+* `make hook`: update `~/.git-support/hooks/pre-commit` from local `pre-commit.sh`
+* `make patterns`: update the `gitleaks` configuration in `~/.git-support/gitleaks.toml` from local `local.toml`
+* `make audit`: see that everything work together.
 
-## Testing bats tests
+## Running bats tests
 
-To test bats tests, start a subshell, load in the functions from `test_helper.bash`,
-then be sure to run `setup` before any test to populate `$REPO_PATH` and so on.  For
-example:
+To run a file of bats tests:
 
-``` sh
-bash # start a new shell
-source test_helper.bash # load all the helper functions
-setup
-addFileWithNoSecrets # do the failing thing
-echo $?
-^D
+```shell
+./test/bats/bin/bats -p caulked.bats
+```
+
+To run a specific test or set of tests, pass in a `--filter` argument with a regular expression matching the test(s) you want to run:
+
+```shell
+./test/bats/bin/bats -p caulked.bats --filter "leak prevention.*"
 ```
 
 ## Rule sets
 
 The following rule sets helped inform our gitleaks.toml:
 
-* https://github.com/GSA/odp-code-repository-commit-rules/blob/master/gitleaks/rules.toml - used for guidance
-* https://github.com/zricethezav/gitleaks/blob/master/examples/leaky-repo.toml - used verbatim except for removing certain rulesets.
+* <https://github.com/GSA/odp-code-repository-commit-rules/blob/master/gitleaks/rules.toml> - used for guidance
+* <https://github.com/gitleaks/gitleaks/blob/master/config/gitleaks.toml> - default gitleaks configuration that our configuration extends from
 
 ## What about other hooks? Will they still run?
 
-Yes. Caulking runs your other precommit hooks automatically.
+Yes. Caulking runs your other pre-commit hooks automatically.
 
-Note: if you're using [pre-commit](https://pre-commit.com/) to manage pre-commit hooks, you'll likely get an error like this when running `pre-commit install`:
-```
+### pre-commit.com
+
+**Note:** if you're using [pre-commit](https://pre-commit.com/) to manage pre-commit hooks, you'll likely get an error like this when running `pre-commit install`:
+
+```shell
 [ERROR] Cowardly refusing to install hooks with `core.hooksPath` set.
 hint: `git config --unset-all core.hooksPath`
 ```
+
 You can work around this by running:
-```
+
+```shell
 hookspath=$(git config core.hookspath)
 git config --global --unset-all core.hookspath
 pre-commit install
 git config --global core.hookspath "${hookspath}"
 ```
+
+[See the GitHub issue for the related discussion.](https://github.com/pre-commit/pre-commit/issues/1198).
 
 ## Incompatible gitleaks changes
 
@@ -160,19 +136,21 @@ Sometimes gitleaks updates will have breaking changes, and you'll need to compar
 between the current version and an older version. To install an older gitleaks version with `brew`:
 
 * Browse the [brew history for the gitleaks formula](https://github.com/Homebrew/homebrew-core/commits/master/Formula/gitleaks.rb)
-* Find the `commit` that matches the older version you want to roll back to
+* Find the commit that matches the older version you want to roll back to
 * Then run:
-  ```
-  wget https://raw.githubusercontent.com/Homebrew/homebrew-core/<commit>/Formula/gitleaks.rb
-  brew unlink gitleaks
-  brew install ./gitleaks.rb
-  ```
+
+    ```shell
+    wget https://raw.githubusercontent.com/Homebrew/homebrew-core/<commit>/Formula/gitleaks.rb
+    brew unlink gitleaks
+    brew install ./gitleaks.rb
+    ```
+
 * You'll now have the older version.
 
-# Public domain
+## Public domain
 
 This project is in the worldwide public domain. As stated in CONTRIBUTING:
 
 > This project is in the public domain within the United States, and copyright and related rights in the work worldwide are waived through the CC0 1.0 Universal public domain dedication.
-
+>
 > All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/README.md
+++ b/README.md
@@ -70,11 +70,17 @@ Then, remove or fix the offending line.
 You have a couple of choices:
 
 * Submit a PR to improve our patterns (guidance forthcoming)
-* Submit an issue to this repo, and then ignore `gitleaks` _temporarily_ with:
+* Submit an issue to this repo, and then ignore `gitleaks` for the commit with:
 
-```shell
+    ```shell
     SKIP=gitleaks git commit -m "message"
-```
+    ```
+
+    Then type `y` when you see this prompt:
+
+    ```shell
+    Do you want to SKIP gitleaks? [y/n] y
+    ```
 
 ## Development tips
 

--- a/caulked.bats
+++ b/caulked.bats
@@ -56,6 +56,12 @@ load test_helper
     [ ${status} -eq 1 ]
 }
 
+@test "repo runs gitleaks and local githooks" {
+    run testLocalGitHook
+    assert_output --partial "foobar"
+    assert_output --partial "no leaks found"
+}
+
 @test "repos have hooks.gitleaks set to true" {
     ./check_repos.sh $HOME check_hooks_gitleaks >&3
 }

--- a/caulked.bats
+++ b/caulked.bats
@@ -66,8 +66,8 @@ load test_helper
     ./check_repos.sh $HOME check_hooks_gitleaks >&3
 }
 
-@test "repos are using precommit hooks with gitleaks" {
-    ./check_repos.sh $HOME check_precommit_hook >&3
+@test "repos are not overriding the core hooks path" {
+    ./check_repos.sh $HOME check_hooks_path >&3
 }
 
 @test "the ~/.aws directory is free of AWS keys" {

--- a/check_repos.sh
+++ b/check_repos.sh
@@ -42,10 +42,6 @@ check_hooks_gitleaks() {
 
 check_hooks_path() {
     # ensure that repos are not overriding the hookspath
-    hooks_path=$(cd "$gitrepo"; git config --local core.hooksPath)
-    if [ "$hooks_path" != "" ]; then
-        return 1
-    fi
     hooks_path_origin=$(cd "$gitrepo"; git config --show-origin core.hooksPath)
     if [[ "$hooks_path_origin" =~ /^file:$HOME/.gitconfig.*$HOME/.git-support/hooks ]]; then
         return 1

--- a/check_repos.sh
+++ b/check_repos.sh
@@ -1,26 +1,28 @@
-#! /bin/bash -euo pipefail
+#!/bin/bash
+
+set -euo pipefail
 
 MAXDEPTH=5
 USER_DOMAIN=gsa.gov
 
 # MAXDEPTH 5 assumes a home directory structure that's no deeper than this:
 #       $HOME/(projects)/(organization)/(repository)/(another_dir)/(yet_another_dir)
-# Depth 0   / 1         / 2           / 3           / 4           / 5 
+# Depth 0   / 1         / 2           / 3           / 4           / 5
 
 fail() {
-    echo $@
+    echo "$@"
     echo "Usage: $0 root_dir (check_precommit_hook | check_hooks_gitleak | check_user_email)"
     exit 2
 }
 
-[ $# = 2 ] || fail "need two args" 
-if [ ! -d $1 ]; then 
+[ $# = 2 ] || fail "need two args"
+if [ ! -d "$1" ]; then
     fail "first argument must be a directory"
 else
     root=$1
-fi 
+fi
 
-case $2 in 
+case $2 in
    check_hooks_gitleaks|check_precommit_hook|check_user_email)
         option=$2
         :;;
@@ -30,7 +32,7 @@ esac
 exit_status=0
 
 check_hooks_gitleaks() {
-    hooks_gitleak=$(cd $gitrepo; git config --bool hooks.gitleaks)
+    hooks_gitleak=$(cd "$gitrepo"; git config --bool hooks.gitleaks)
     if [ "$hooks_gitleak" = "true" ]; then
         return 0
     else
@@ -39,15 +41,15 @@ check_hooks_gitleaks() {
 }
 
 check_precommit_hook() {
-    if [ -f $gitrepo/hooks/pre-commit ]; then
-      pcregrep -q '^((?!#).)*gitleaks\s+protect' $gitrepo/hooks/pre-commit
+    if [ -f "$gitrepo/hooks/pre-commit" ]; then
+      pcregrep -q '^((?!#).)*gitleaks\s+protect' "$gitrepo/hooks/pre-commit"
       return $?
     fi
     return 0
 }
 
 check_user_email() {
-    user_domain=$(cd $gitrepo; git config user.email | cut -d @ -f 2)
+    user_domain=$(cd "$gitrepo"; git config user.email | cut -d @ -f 2)
     if [ "$user_domain" = "$USER_DOMAIN" ]; then
         return 0
     else
@@ -57,13 +59,13 @@ check_user_email() {
 
 # read gitrepo list from `find` using Process Substitution
 # so exit_status isn't in a subshell
-while read gitrepo; do 
-    if eval $option $gitrepo; then
-        :
-    else
+while read -r gitrepo; do
+    if ! eval "$option" "$gitrepo"; then
         echo "FAIL $option for repository: $gitrepo" 1>&2
         exit_status=1
     fi
-done <<< "$( find $root -name '.git' -type d -maxdepth $MAXDEPTH 2>/dev/null )"
+done <<< "$( find "$root" -name '.git' -type d -maxdepth $MAXDEPTH 2>/dev/null )"
 
-exit $exit_status 
+if [ $exit_status -ne 0 ]; then
+    exit $exit_status
+fi

--- a/development.bats
+++ b/development.bats
@@ -25,30 +25,6 @@ testCommit() {
     assert_failure
 }
 
-@test "check_repo fails if repo precommit is missing gitleaks" {
-    (cd $REPO_PATH && mv .git/hooks/pre-commit.sample .git/hooks/pre-commit)
-    run ./check_repos.sh $REPO_PATH check_precommit_hook >&3
-    assert_failure
-}
-
-@test "check_repo fails if gitleaks is commented out" {
-    cat >$REPO_PATH/.git/hooks/pre-commit <<END
-# lets not run gitleaks protect
-END
-    run ./check_repos.sh $REPO_PATH check_precommit_hook >&3
-    assert_failure
-}
-
-@test "check_repo OK with repo and a valid precommit hook" {
-    cat >$REPO_PATH/.git/hooks/pre-commit <<END
-#!/bin/sh
-echo special stuff
-$HOME/bin/gitleaks  protect --foo
-END
-    run ./check_repos.sh $REPO_PATH check_precommit_hook >&3
-    assert_success
-}
-
 @test "check_repo fails when you have a personal email" {
     git config --file $REPO_PATH/.git/config user.email foo@bar.com
     run ./check_repos.sh $REPO_PATH check_user_email >&3

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -113,6 +113,16 @@ $1
 END
     testCommit $secrets_file
 }
+
+testLocalGitHook() {
+    local test_precommit_hook="${REPO_PATH}/.git/hooks/pre-commit"
+    cat >"${test_precommit_hook}" <<END
+echo foobar
+END
+    chmod 755 "$test_precommit_hook"
+    testCommit "$test_precommit_hook"
+}
+
 ##########################
 # for development purposes
 ##########################


### PR DESCRIPTION
## Changes proposed in this pull request:

Addresses #37

As noted in #37, it is possible to have local git hooks and gitleaks co-exist, but the tests run by `make audit` assume that is not possible. To fix this behavior, this PR:

- Adds a test to prove that local git hooks and gitleaks both run on a test repo
- Removes the test that fails `make audit` if a repo has a custom `.git/hooks/pre-commit` hook, since this scenario does not actually prevent gitleaks from running
- Adds a test to prove that `core.hooksPath` is not overridden at the repo level, which **would prevent gitleaks from running**

Other unrelated fixes in the PR include:

- Updates to README to remove outdated information
- Refactor shell scripts based on shellcheck recommendations

## security considerations

This PR should be correcting a misunderstanding of how git hooks work but not actually introducing any chance that the global git hook for gitleaks won't run. However, the changes should be audited carefully to avoid any possible regression
