### PR TITLE
Fix check for overridden hooks path

### DIFF
--- a/check_repos.sh
+++ b/check_repos.sh
@@ -42,8 +42,8 @@ check_hooks_gitleaks() {
 
 check_hooks_path() {
     # ensure that repos are not overriding the hookspath
-    hooks_path_origin=$(cd "$gitrepo"; git config --show-origin core.hooksPath)
-    if [[ "$hooks_path_origin" =~ /^file:$HOME/.gitconfig.*$HOME/.git-support/hooks ]]; then
+    hooks_path_origin=$(cd "$gitrepo"; git config --show-origin core.hooksPath | awk '{print $2}')
+    if [[ "$hooks_path_origin" != "${HOME}/.git-support/hooks" ]]; then
         return 1
     fi
     return 0

--- a/development.bats
+++ b/development.bats
@@ -25,6 +25,11 @@ testCommit() {
     assert_failure
 }
 
+@test "check_repo fails when core.hooksPath is overridden" {
+    run changeGitHooksPath
+    assert_failure
+}
+
 @test "check_repo fails when you have a personal email" {
     git config --file $REPO_PATH/.git/config user.email foo@bar.com
     run ./check_repos.sh $REPO_PATH check_user_email >&3

--- a/test_helper.bash
+++ b/test_helper.bash
@@ -131,6 +131,11 @@ turnOffHooksGitleaks() {
     ./check_repos.sh $REPO_PATH check_hooks_gitleaks
 }
 
+changeGitHooksPath() {
+    (cd $REPO_PATH && git config --local core.hooksPath "foobar")
+    ./check_repos.sh $REPO_PATH check_hooks_path
+}
+
 createPrecommitNoGitleaks() {
     (cd $REPO_PATH && mv .git/hooks/pre-commit.sample .git/hooks/pre-commit)
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

Follow-up to #89 

We discovered that for repos which were overriding `core.hooksPath`, such as those using tools like [husky](https://github.com/typicode/husky), `gitleaks` was not running. [And the test in `make audit` that should catch when `core.hooksPath` is overridden](https://github.com/cloud-gov/caulking/blob/a303ab639da717a06f23f1e5b00c1d49e3e4f2ec/check_repos.sh#L43-L50) was not failing on these repos.

This PR fixes the check to correctly detect when `core.hooksPath` is overridden and fails appropriately. The PR also adds a CI test to ensure that this behavior works as expected.

## security considerations

This PR improves security by ensuring that `make audit` for `gitleaks` will fail on any repo where `core.hooksPath` is overridden, which in turn prevents `gitleaks` from running. The `make audit` failure should in turn force the repo owners to remove the override for `core.hooksPath`.
