### PR TITLE
feat: Remove clean_seekrets make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,13 +33,6 @@ clean:
 	git config --global --unset core.hooksPath
 	/bin/rm -rf ${GITLEAKS}
 
-clean_seekrets:
-	/bin/rm -rf ${GIT_SUPPORT_PATH}/seekret-rules
-	-git config --global --unset gitseekret.rulesenabled
-	-git config --global --unset gitseekret.rulespath
-	-git config --global --unset gitseekret.exceptionsfile
-	-git config --global --unset gitseekret.version
-
 hook pre-commit: ${GIT_SUPPORT_PATH}/hooks/pre-commit
 
 global_hooks:

--- a/README.md
+++ b/README.md
@@ -21,11 +21,6 @@ Clone the repository with the `--recurse-submodules` flag. Or, if you have alrea
 
 You now have the gitleaks pre-commit hook enabled globally.
 
-### If you're upgrading
-
-Before `gitleaks`, prior versions of `caulking` relied on `git-seekrets` - if you have
-an old `git-seekrets`-based caulking install you can remove it with `make clean_seekrets`
-
 ## Bug warning
 
 If you get the error `reference not found` on a new repository, be sure you've run `brew upgrade gitleaks` to install version 4.1.1 or later.


### PR DESCRIPTION
seekrets has been deprecated for a very long time, so we don't need to think about it at all anymore


## Changes proposed in this pull request:
- remove clean_seekrets make target


## security considerations
Because we audit `caulking` installations periodically, and `git-seekrets` has been deprecated for a long time, this should have no affect on our security posture
