### PR TITLE
Update allowed example values

### DIFF
--- a/local.toml
+++ b/local.toml
@@ -11,7 +11,7 @@ useDefault = true
 		'''caulked.bats''',
 		'''local.toml'''
 	]
-	regexes	= ['''CHANGEME|changeme|feedabee|EXAMPLE|23.22.13.113|1234567890''']
+	regexes	= ['''CHANGEME|changeme|feedabee|not-actually-secret|EXAMPLE|23.22.13.113|1234567890''']
 
 # Rules borrowed from GSA
 # https://github.com/GSA/odp-code-repository-commit-rules/blob/master/gitleaks/rules.toml


### PR DESCRIPTION
## Changes proposed in this pull request:

- Add `not-actually-secret` as an allowed example value for gitleaks


## security considerations

Adds an additional allowed value for secrets detection, marginally increasing the possibility of false negatives, though hopefully a human will catch if `not-actually-secret` is being used for a thing that actually requires secrecy