### PR TITLE
Declare prompt and ans as local function variables

### DIFF
--- a/pre-commit.sh
+++ b/pre-commit.sh
@@ -16,7 +16,7 @@ fi
 #   10: user entered no
 #
 prompt_yn() {
-  prompt ans
+  local prompt ans
   if [ $# -ge 1 ]; then
     prompt="$1"
   else


### PR DESCRIPTION
## Changes proposed in this pull request:
- add back `local` keyword that had been lost previously

## security considerations

Prevents unknown behavior if someone does have a `prompt` command in their PATH
